### PR TITLE
[WIP] Lapack

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -106,6 +106,7 @@ TiledArray/external/btas.h
 TiledArray/math/blas.h
 TiledArray/math/eigen.h
 TiledArray/math/gemm_helper.h
+TiledArray/math/lapack/chol.h
 TiledArray/math/lapack/heig.h
 TiledArray/math/linear_algebra.h
 TiledArray/math/outer.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -106,6 +106,8 @@ TiledArray/external/btas.h
 TiledArray/math/blas.h
 TiledArray/math/eigen.h
 TiledArray/math/gemm_helper.h
+TiledArray/math/lapack/heig.h
+TiledArray/math/linear_algebra.h
 TiledArray/math/outer.h
 TiledArray/math/parallel_gemm.h
 TiledArray/math/partial_reduce.h

--- a/src/TiledArray/conversions/eigen.h
+++ b/src/TiledArray/conversions/eigen.h
@@ -576,7 +576,7 @@ inline A row_major_buffer_to_array(
   typedef Eigen::Matrix<typename A::value_type::value_type, Eigen::Dynamic,
                         Eigen::Dynamic, Eigen::RowMajor>
       matrix_type;
-  return eigen_to_array(
+  return eigen_to_array<A>(
       world, trange,
       Eigen::Map<const matrix_type, Eigen::AutoAlign>(buffer, m, n),
       replicated);

--- a/src/TiledArray/conversions/eigen.h
+++ b/src/TiledArray/conversions/eigen.h
@@ -638,7 +638,7 @@ inline A column_major_buffer_to_array(
   typedef Eigen::Matrix<typename A::value_type::value_type, Eigen::Dynamic,
                         Eigen::Dynamic, Eigen::ColMajor>
       matrix_type;
-  return eigen_to_array(
+  return eigen_to_array<A>(
       world, trange,
       Eigen::Map<const matrix_type, Eigen::AutoAlign>(buffer, m, n),
       replicated);

--- a/src/TiledArray/conversions/make_array.h
+++ b/src/TiledArray/conversions/make_array.h
@@ -26,8 +26,10 @@
 #ifndef TILEDARRAY_CONVERSIONS_MAKE_ARRAY_H__INCLUDED
 #define TILEDARRAY_CONVERSIONS_MAKE_ARRAY_H__INCLUDED
 
-#include <TiledArray/external/madness.h>
-#include <TiledArray/type_traits.h>
+#include "TiledArray/external/madness.h"
+#include "TiledArray/shape.h"
+#include "TiledArray/type_traits.h"
+
 
 /// Forward declarations
 namespace Eigen {

--- a/src/TiledArray/expressions/contraction_helpers.h
+++ b/src/TiledArray/expressions/contraction_helpers.h
@@ -20,6 +20,7 @@
 #ifndef TILEDARRAY_EXPRESSIONS_CONTRACTION_HELPERS_H__INCLUDED
 #define TILEDARRAY_EXPRESSIONS_CONTRACTION_HELPERS_H__INCLUDED
 
+#include "TiledArray/conversions/make_array.h"
 #include "TiledArray/expressions/tsr_expr.h"
 #include "TiledArray/expressions/variable_list.h"
 #include "TiledArray/tensor/tensor.h"
@@ -563,7 +564,7 @@ void einsum(TsrExpr<ResultType, true> out,
       trange_from_annotation(bound_vars, lhs_ovars, rhs_ovars, ltensor, rtensor);
 
 
-  auto l = [=](auto& tile, const TA::Range& r){
+  auto l = [=](auto& tile, const Range& r){
 
     const auto oidx =
         orange.tiles_range().idx(orange.element_to_tile(r.lobound()));

--- a/src/TiledArray/math/lapack/chol.h
+++ b/src/TiledArray/math/lapack/chol.h
@@ -59,13 +59,12 @@ auto cholesky_linv(const Array& A) {
   int ncols = L_eigen.cols();
   int info;
   if constexpr(std::is_same_v<numeric_type, double>){
-    dpotri("L", &nrows, L_eigen.data(), &ncols, &info);
+    dtrtri("L", "N", &nrows, L_eigen.data(), &ncols, &info);
   } else {
     TA_EXCEPTION("Your numeric type is not hooked up at the moment");
   }
-  // We only get the lower triangle back
   for(auto i = 0; i < nrows; ++i)
-    for(auto j = i + 1; j < ncols; ++j)L_eigen(i,j) = L_eigen(j, i);
+    for(auto j = i + 1; j < ncols; ++j) L_eigen(i,j) = 0.0;
 
   return column_major_buffer_to_array<tensor_type>(
       A.world(), A.trange(), L_eigen.data(), nrows, ncols);

--- a/src/TiledArray/math/lapack/chol.h
+++ b/src/TiledArray/math/lapack/chol.h
@@ -1,0 +1,82 @@
+#ifndef TILEDARRAY_MATH_LAPACK_CHOL_H__INCLUDED
+#define TILEDARRAY_MATH_LAPACK_CHOL_H__INCLUDED
+#include "TiledArray/conversions/eigen.h"
+
+namespace TiledArray::lapack {
+namespace detail {
+
+/// \brief Peforms Cholesky, but does not convert back to a DistArray
+///
+/// Cholesky decomposition is the first step of `cholesky_linv` and
+/// `cholesky_solve`, but if we try to write them in terms of `cholesky` we'll
+/// end up creating a DistArray with L, only to have to take it apart again.
+/// This function is the guts of the `cholesky` function without the conversion
+/// to a DistArray.
+///
+/// @tparam Array
+/// @param A
+/// @return
+template <typename Array>
+auto cholesky_(const Array& A) {
+  using tensor_type = Array;
+  using numeric_type = typename tensor_type::numeric_type;
+
+  auto A_eigen = array_to_eigen(A);
+  int nrows = A_eigen.rows();
+  int ncols = A_eigen.cols();
+  int info;
+  if constexpr (std::is_same_v<numeric_type, double>) {
+    dpotrf("L", &nrows, A_eigen.data(), &ncols, &info);
+  } else {
+    TA_EXCEPTION("Your numeric type is not hooked up at the moment");
+  }
+
+  // I think I need to zero out the upper triangle, but I'm not 100% sure...
+  for (auto i = 0; i < nrows; ++i)
+    for (auto j = i + 1; j < ncols; ++j) A_eigen(i, j) = 0.0;
+  return A_eigen;
+}
+
+} // namespace detail
+
+
+template <typename Array>
+auto cholesky(const Array& A) {
+  using tensor_type = Array;
+  auto L_eigen = detail::cholesky_(A);
+  const auto nrows = A.elements_range().upbound(0);
+  return column_major_buffer_to_array<tensor_type>(
+      A.world(), A.trange(), L_eigen.data(), nrows, nrows);
+}
+
+template<typename Array>
+auto cholesky_linv(const Array& A) {
+  using tensor_type = Array;
+  using numeric_type = typename tensor_type::numeric_type;
+
+  auto L_eigen = detail::cholesky_(A);
+  int nrows = L_eigen.rows();
+  int ncols = L_eigen.cols();
+  int info;
+  if constexpr(std::is_same_v<numeric_type, double>){
+    dpotri("L", &nrows, L_eigen.data(), &ncols, &info);
+  } else {
+    TA_EXCEPTION("Your numeric type is not hooked up at the moment");
+  }
+  // We only get the lower triangle back
+  for(auto i = 0; i < nrows; ++i)
+    for(auto j = i + 1; j < ncols; ++j)L_eigen(i,j) = L_eigen(j, i);
+
+  return column_major_buffer_to_array<tensor_type>(
+      A.world(), A.trange(), L_eigen.data(), nrows, ncols);
+}
+
+template<typename Array>
+auto cholesky_solve(const Array& A, const Array& B) {
+  TA_EXCEPTION("LAPACK version is not implemented");
+}
+
+
+} // namespace TiledArray::lapack
+
+#endif // TILEDARRAY_MATH_LAPACK_CHOL_H__INCLUDED

--- a/src/TiledArray/math/lapack/heig.h
+++ b/src/TiledArray/math/lapack/heig.h
@@ -1,0 +1,61 @@
+#ifndef TILEDARRAY_MATH_LAPACK_HEIG_H__INCLUDED
+#define TILEDARRAY_MATH_LAPACK_HEIG_H__INCLUDED
+#include "TiledArray/conversions/retile.h"
+
+namespace TiledArray {
+namespace lapack {
+
+template <typename Array>
+auto heig(const Array& A) {
+  using tensor_type = Array;
+  using tile_type = typename tensor_type::value_type;
+
+  auto& world = A.world();
+
+  const auto& erange = A.elements_range();
+  const auto nrows = erange.hi(0);
+  const auto ncols = erange.hi(1);
+
+  TA::TiledRange matrix_tile{{0, nrows}, {0, ncols}};
+  auto A_large_tile = retile(A, matrix_tile);
+  tile_type evec_buffer;
+  tile_type eval_buffer;
+
+  if (A_large_tile.is_local({0, 0})) {
+    eval_buffer = tile_type(TA::Range{nrows}, 0.0);
+    evec_buffer = A_large_tile.find({0, 0}).get();
+    int lwork = 1 + 6 * nrows + 2 * nrows * nrows;
+    int info;
+    std::vector<double> work(lwork);
+    dsyev("V", "U", &nrows, evec_buffer.data(), &ncols, eval_buffer.data(),
+          work.data(), &lwork, &info);
+    auto row_major = evec_buffer.permute(TA::Permutation{1, 0});
+    evec_buffer = row_major;
+  }
+
+  auto l = [=](tile_type& tile, const auto&) {
+    tile = evec_buffer;
+    return tile.norm();
+  };
+
+  auto m = [=](tile_type& tile, const auto&) {
+    tile = eval_buffer;
+    return tile.norm();
+  };
+
+  auto pmap = A_large_tile.pmap();
+
+  auto evecs = make_array<tensor_type>(world, matrix_tile, pmap, l);
+
+  auto evals = make_array<tensor_type>(
+      world, TA::TiledRange{matrix_tile.dim(0)}, pmap, m);
+
+  auto tiled_evecs = retile(evecs, A.trange());
+  auto tiled_evals = retile(evals, TA::TiledRange{A.trange().dim(0)});
+  return std::tuple(tiled_evals, tiled_evecs);
+}
+
+}
+} // namespace TiledArray
+
+#endif

--- a/src/TiledArray/math/lapack/heig.h
+++ b/src/TiledArray/math/lapack/heig.h
@@ -16,12 +16,16 @@ auto heig(const Array& A) {
   const int nrows = A_eigen.rows();
   const int ncols = A_eigen.cols();
 
-  int lwork = 1 + 6 * nrows + 2 * nrows * nrows;
+  int lwork = -1;
   int info;
-  std::vector<numeric_type> work(lwork);
+  std::vector<numeric_type> work(1);
   std::vector<numeric_type> eval_buffer(nrows);
 
   if constexpr(std::is_same_v<numeric_type, double>) {
+    dsyev("V", "U", &nrows, A_eigen.data(), &ncols, eval_buffer.data(),
+          work.data(), &lwork, &info);
+    lwork = work[0];
+    work = std::vector<numeric_type>(lwork);
     dsyev("V", "U", &nrows, A_eigen.data(), &ncols, eval_buffer.data(),
           work.data(), &lwork, &info);
   }
@@ -60,19 +64,28 @@ auto heig(const Array& A, const Array& B) {
   const int nrows = A_eigen.rows();
   const int ncols = A_eigen.cols();
 
-  int lwork = 1 + 6 * nrows + 2 * nrows * nrows;
-  int liwork = 3 + 5 * nrows;
+  int lwork = -1;
+  int liwork = -1;
   int info;
-  std::vector<numeric_type> work(lwork);
   std::vector<numeric_type> eval_buffer(nrows);
-  std::vector<int> iwork(liwork);
+  std::vector<numeric_type> work(1);
+  std::vector<int> iwork(1);
 
   if constexpr(std::is_same_v<numeric_type, double>) {
     int one = 1;
-
+    // First call gets optimial sizes
     dsygvd(&one, "V", "U", &nrows, A_eigen.data(), &ncols, B_eigen.data(),
            &ncols, eval_buffer.data(), work.data(), &lwork, iwork.data(),
            &liwork, &info);
+    lwork = work[0];
+    liwork = iwork[0];
+    work = std::vector<numeric_type>(lwork);
+    iwork = std::vector<int>(liwork);
+    // This call does the real work
+    dsygvd(&one, "V", "U", &nrows, A_eigen.data(), &ncols, B_eigen.data(),
+           &ncols, eval_buffer.data(), work.data(), &lwork, iwork.data(),
+           &liwork, &info);
+
   }
   else {
     TA_EXCEPTION("Your numeric type is not hooked up at the moment");

--- a/src/TiledArray/math/linear_algebra.h
+++ b/src/TiledArray/math/linear_algebra.h
@@ -1,0 +1,29 @@
+#ifndef TILEDARRAY_MATH_LINEAR_ALGEBRA_H__INCLUDED
+#define TILEDARRAY_MATH_LINEAR_ALGEBRA_H__INCLUDED
+#include "TiledArray/math/scalapack.h"
+#include "TiledArray/math/lapack/heig.h"
+#include "TiledArray/config.h"
+
+namespace TiledArray {
+
+template<typename Array>
+auto heig(const Array& A) {
+  // TODO: Check if tensor is distributed, if not don't use SCALAPACK
+
+#if TILEDARRAY_HAS_SCALAPACK
+  return scalapack::heig(A);
+#else
+  return lapack::heig(A);
+}
+
+template<typename Array>
+auto heig(const Array& A, const Array& B) {
+  // TODO: Check if tensor is distributed, if not don't use SCALAPACK
+
+#if TILEDARRAY_HAS_SCALAPACK
+  return scalapack::heig(A, B);
+#else
+  return lapack::heig(A, B);
+}
+
+}

--- a/src/TiledArray/math/linear_algebra.h
+++ b/src/TiledArray/math/linear_algebra.h
@@ -13,8 +13,20 @@ auto heig(const Array& A) {
 
 template<typename Array>
 auto heig(const Array& A, const Array& B) {
-  return detail::use_scalapack(A, B) ?
-                                     scalapack::heig(A, B) : lapack::heig(A, B);
+  const bool = scalapack = detail::use_scalapack(A, B);
+  return scalapack ? scalapack::heig(A, B) : lapack::heig(A, B);
+}
+
+template<typename Array>
+auto cholesky(const Array& A) {
+  const bool = scalapack = detail::use_scalapack(A);
+  return scalapack(A) ? scalapack::cholesky(A) : lapack::cholesky(A);
+}
+
+template<typename Array>
+auto cholesky_linv(const Array& A) {
+  const bool = scalapack = detail::use_scalapack(A);
+  return scalapack(A) ? scalapack::cholesky_linv(A) : lapack::cholesky_linv(A);
 }
 
 }

--- a/src/TiledArray/math/linear_algebra.h
+++ b/src/TiledArray/math/linear_algebra.h
@@ -1,6 +1,7 @@
 #ifndef TILEDARRAY_MATH_LINEAR_ALGEBRA_H__INCLUDED
 #define TILEDARRAY_MATH_LINEAR_ALGEBRA_H__INCLUDED
 #include "TiledArray/math/scalapack.h"
+#include "TiledArray/math/lapack/chol.h"
 #include "TiledArray/math/lapack/heig.h"
 #include "TiledArray/config.h"
 
@@ -13,20 +14,20 @@ auto heig(const Array& A) {
 
 template<typename Array>
 auto heig(const Array& A, const Array& B) {
-  const bool = scalapack = detail::use_scalapack(A, B);
+  const bool scalapack = detail::use_scalapack(A, B);
   return scalapack ? scalapack::heig(A, B) : lapack::heig(A, B);
 }
 
 template<typename Array>
 auto cholesky(const Array& A) {
-  const bool = scalapack = detail::use_scalapack(A);
-  return scalapack(A) ? scalapack::cholesky(A) : lapack::cholesky(A);
+  const bool scalapack = detail::use_scalapack(A);
+  return scalapack? scalapack::cholesky(A) : lapack::cholesky(A);
 }
 
 template<typename Array>
 auto cholesky_linv(const Array& A) {
-  const bool = scalapack = detail::use_scalapack(A);
-  return scalapack(A) ? scalapack::cholesky_linv(A) : lapack::cholesky_linv(A);
+  const bool scalapack = detail::use_scalapack(A);
+  return scalapack ? scalapack::cholesky_linv(A) : lapack::cholesky_linv(A);
 }
 
 }

--- a/src/TiledArray/math/linear_algebra.h
+++ b/src/TiledArray/math/linear_algebra.h
@@ -8,22 +8,15 @@ namespace TiledArray {
 
 template<typename Array>
 auto heig(const Array& A) {
-  // TODO: Check if tensor is distributed, if not don't use SCALAPACK
-
-#if TILEDARRAY_HAS_SCALAPACK
-  return scalapack::heig(A);
-#else
-  return lapack::heig(A);
+  return detail::use_scalapack(A) ? scalapack::heig(A) : lapack::heig(A);
 }
 
 template<typename Array>
 auto heig(const Array& A, const Array& B) {
-  // TODO: Check if tensor is distributed, if not don't use SCALAPACK
-
-#if TILEDARRAY_HAS_SCALAPACK
-  return scalapack::heig(A, B);
-#else
-  return lapack::heig(A, B);
+  return detail::use_scalapack(A, B) ?
+                                     scalapack::heig(A, B) : lapack::heig(A, B);
 }
 
 }
+
+#endif // TILEDARRAY_MATH_LINEAR_ALGEBRA_H__INCLUDED

--- a/src/TiledArray/math/scalapack.h
+++ b/src/TiledArray/math/scalapack.h
@@ -25,9 +25,31 @@
 #ifndef TILEDARRAY_MATH_SCALAPACK_H__INCLUDED
 #define TILEDARRAY_MATH_SCALAPACK_H__INCLUDED
 
+#include <TiledArray/math/scalapack/heig.h>
+
+namespace TiledArray::detail {
+
+/// \brief Determines whether we should use the ScaLAPACK implementation of the
+///        linear algebra routine or not
+///
+/// @tparam TensorTypes The type of the tensors we are performing linear algebra
+///                     on. Expected to be TA::DistArray instances.
+/// @param ts
+/// @return
+template<typename...TensorTypes>
+bool use_scalapack(TensorTypes&&...ts) {
+  // TODO: Check if tensor ts are distributed, if not don't use SCALAPACK
+#if TILEDARRAY_HAS_SCALAPACK
+  return true;
+#else
+  return false;
+#endif
+}
+
+} //namespace TiledArray::detail
+
 #if TILEDARRAY_HAS_SCALAPACK
 
-#include <TiledArray/math/scalapack/heig.h>
 #include <TiledArray/math/scalapack/chol.h>
 #include <TiledArray/math/scalapack/svd.h>
 #include <TiledArray/math/scalapack/lu.h>

--- a/src/TiledArray/math/scalapack.h
+++ b/src/TiledArray/math/scalapack.h
@@ -26,6 +26,7 @@
 #define TILEDARRAY_MATH_SCALAPACK_H__INCLUDED
 
 #include <TiledArray/math/scalapack/heig.h>
+#include <TiledArray/math/scalapack/chol.h>
 
 namespace TiledArray::detail {
 
@@ -50,7 +51,6 @@ bool use_scalapack(TensorTypes&&...ts) {
 
 #if TILEDARRAY_HAS_SCALAPACK
 
-#include <TiledArray/math/scalapack/chol.h>
 #include <TiledArray/math/scalapack/svd.h>
 #include <TiledArray/math/scalapack/lu.h>
 

--- a/src/TiledArray/math/scalapack/chol.h
+++ b/src/TiledArray/math/scalapack/chol.h
@@ -32,11 +32,11 @@
 #include <TiledArray/math/scalapack/util.h>
 
 #include <scalapackpp/factorizations/potrf.hpp>
-#include <scalapackpp/matrix_inverse/trtri.hpp>
 #include <scalapackpp/linear_systems/posv.hpp>
 #include <scalapackpp/linear_systems/trtrs.hpp>
+#include <scalapackpp/matrix_inverse/trtri.hpp>
 
-namespace TiledArray {
+namespace TiledArray::scalapack {
 
 /**
  *  @brief Compute the Cholesky factorization of a HPD rank-2 tensor
@@ -51,54 +51,45 @@ namespace TiledArray {
  *
  *  @param[in] A           Input array to be diagonalized. Must be rank-2
  *  @param[in] NB          ScaLAPACK blocking factor. Defaults to 128
- *  @param[in] l_trange    TiledRange for resulting Cholesky factor. If left empty,
- *                         will default to array.trange()
+ *  @param[in] l_trange    TiledRange for resulting Cholesky factor. If left
+ * empty, will default to array.trange()
  *
  *  @returns The lower triangular Cholesky factor L in TA format
  */
 template <typename Array>
-auto cholesky( const Array& A, size_t NB = 128, TiledRange l_trange = TiledRange() ) {
-
+auto cholesky(const Array& A, size_t NB = 128,
+              TiledRange l_trange = TiledRange()) {
   using value_type = typename Array::element_type;
 
   auto& world = A.world();
   auto world_comm = world.mpi.comm().Get_mpi_comm();
   blacspp::Grid grid = blacspp::Grid::square_grid(world_comm);
 
-  world.gop.fence(); // stage ScaLAPACK execution
-  auto matrix = array_to_block_cyclic( A, grid, NB, NB );
-  world.gop.fence(); // stage ScaLAPACK execution
+  world.gop.fence();  // stage ScaLAPACK execution
+  auto matrix = array_to_block_cyclic(A, grid, NB, NB);
+  world.gop.fence();  // stage ScaLAPACK execution
 
   auto [M, N] = matrix.dims();
-  if( M != N )
-    throw std::runtime_error("Matrix must be square for Cholesky");
+  if (M != N) throw std::runtime_error("Matrix must be square for Cholesky");
 
   auto [Mloc, Nloc] = matrix.dist().get_local_dims(N, N);
   auto desc = matrix.dist().descinit_noerror(N, N, Mloc);
 
-  auto info = scalapackpp::ppotrf( blacspp::Triangle::Lower, N,
-    matrix.local_mat().data(), 1, 1, desc );
+  auto info = scalapackpp::ppotrf(blacspp::Triangle::Lower, N,
+                                  matrix.local_mat().data(), 1, 1, desc);
   if (info) throw std::runtime_error("Cholesky Failed");
 
   // Zero out the upper triangle
-  detail::scalapack_zero_triangle( blacspp::Triangle::Upper, matrix );
+  detail::scalapack_zero_triangle(blacspp::Triangle::Upper, matrix);
 
-  if( l_trange.rank() == 0 ) l_trange = A.trange();
+  if (l_trange.rank() == 0) l_trange = A.trange();
 
   world.gop.fence();
-  auto L = block_cyclic_to_array<Array>( matrix, l_trange );
+  auto L = block_cyclic_to_array<Array>(matrix, l_trange);
   world.gop.fence();
-
 
   return L;
-
 }
-
-
-
-
-
-
 
 /**
  *  @brief Compute the inverse of the Cholesky factor of an HPD rank-2 tensor.
@@ -116,191 +107,199 @@ auto cholesky( const Array& A, size_t NB = 128, TiledRange l_trange = TiledRange
  *
  *  @param[in] A           Input array to be diagonalized. Must be rank-2
  *  @param[in] NB          ScaLAPACK blocking factor. Defaults to 128
- *  @param[in] l_trange    TiledRange for resulting inverse Cholesky factor. 
+ *  @param[in] l_trange    TiledRange for resulting inverse Cholesky factor.
  *                         If left empty, will default to array.trange()
  *
  *  @returns The inverse lower triangular Cholesky factor in TA format
  */
 template <typename Array, bool RetL = false>
-auto cholesky_linv( const Array& A, size_t NB = 128, TiledRange l_trange = TiledRange() ) {
-
+auto cholesky_linv(const Array& A, size_t NB = 128,
+                   TiledRange l_trange = TiledRange()) {
   using value_type = typename Array::element_type;
 
   auto& world = A.world();
   auto world_comm = world.mpi.comm().Get_mpi_comm();
   blacspp::Grid grid = blacspp::Grid::square_grid(world_comm);
 
-  world.gop.fence(); // stage ScaLAPACK execution
-  auto matrix = array_to_block_cyclic( A, grid, NB, NB );
-  world.gop.fence(); // stage ScaLAPACK execution
+  world.gop.fence();  // stage ScaLAPACK execution
+  auto matrix = array_to_block_cyclic(A, grid, NB, NB);
+  world.gop.fence();  // stage ScaLAPACK execution
 
   auto [M, N] = matrix.dims();
-  if( M != N )
-    throw std::runtime_error("Matrix must be square for Cholesky");
+  if (M != N) throw std::runtime_error("Matrix must be square for Cholesky");
 
   auto [Mloc, Nloc] = matrix.dist().get_local_dims(N, N);
   auto desc = matrix.dist().descinit_noerror(N, N, Mloc);
 
-  auto info = scalapackpp::ppotrf( blacspp::Triangle::Lower, N,
-    matrix.local_mat().data(), 1, 1, desc );
+  auto info = scalapackpp::ppotrf(blacspp::Triangle::Lower, N,
+                                  matrix.local_mat().data(), 1, 1, desc);
   if (info) throw std::runtime_error("Cholesky Failed");
 
   // Zero out the upper triangle
-  detail::scalapack_zero_triangle( blacspp::Triangle::Upper, matrix );
+  detail::scalapack_zero_triangle(blacspp::Triangle::Upper, matrix);
 
   // Copy L if needed
   std::shared_ptr<BlockCyclicMatrix<value_type>> L_sca = nullptr;
   if constexpr (RetL) {
-    L_sca = std::make_shared<BlockCyclicMatrix<value_type>>(
-      world, grid, N, N, NB, NB
-    );
+    L_sca = std::make_shared<BlockCyclicMatrix<value_type>>(world, grid, N, N,
+                                                            NB, NB);
     L_sca->local_mat() = matrix.local_mat();
   }
 
   // Compute inverse
-  info = scalapackpp::ptrtri( blacspp::Triangle::Lower, 
-    blacspp::Diagonal::NonUnit, N, matrix.local_mat().data(), 1, 1, desc );
+  info =
+      scalapackpp::ptrtri(blacspp::Triangle::Lower, blacspp::Diagonal::NonUnit,
+                          N, matrix.local_mat().data(), 1, 1, desc);
   if (info) throw std::runtime_error("TRTRI Failed");
 
-
-  if( l_trange.rank() == 0 ) l_trange = A.trange();
+  if (l_trange.rank() == 0) l_trange = A.trange();
 
   world.gop.fence();
-  auto Linv = block_cyclic_to_array<Array>( matrix, l_trange );
+  auto Linv = block_cyclic_to_array<Array>(matrix, l_trange);
   world.gop.fence();
-
 
   if constexpr (RetL) {
-    auto L = block_cyclic_to_array<Array>( *L_sca, l_trange);
+    auto L = block_cyclic_to_array<Array>(*L_sca, l_trange);
     world.gop.fence();
-    return std::tuple( L, Linv );
+    return std::tuple(L, Linv);
   } else {
     return Linv;
   }
-
 }
 
-
 template <typename Array>
-auto cholesky_solve( const Array& A, const Array& B, size_t NB = 128, 
-  TiledRange x_trange = TiledRange() ) {
-
+auto cholesky_solve(const Array& A, const Array& B, size_t NB = 128,
+                    TiledRange x_trange = TiledRange()) {
   auto& world = A.world();
   /*
   if( world != B.world() ) {
-    throw std::runtime_error("A and B must be distributed on same MADWorld context");
+    throw std::runtime_error("A and B must be distributed on same MADWorld
+  context");
   }
   */
   auto world_comm = world.mpi.comm().Get_mpi_comm();
   blacspp::Grid grid = blacspp::Grid::square_grid(world_comm);
 
-  world.gop.fence(); // stage ScaLAPACK execution
-  auto A_sca = array_to_block_cyclic( A, grid, NB, NB );
-  auto B_sca = array_to_block_cyclic( B, grid, NB, NB );
-  world.gop.fence(); // stage ScaLAPACK execution
+  world.gop.fence();  // stage ScaLAPACK execution
+  auto A_sca = array_to_block_cyclic(A, grid, NB, NB);
+  auto B_sca = array_to_block_cyclic(B, grid, NB, NB);
+  world.gop.fence();  // stage ScaLAPACK execution
 
   auto [M, N] = A_sca.dims();
-  if( M != N )
-    throw std::runtime_error("A must be square for Cholesky Solve");
+  if (M != N) throw std::runtime_error("A must be square for Cholesky Solve");
 
   auto [B_N, NRHS] = B_sca.dims();
-  if( B_N != N )
-    throw std::runtime_error("A and B dims must agree");
-
+  if (B_N != N) throw std::runtime_error("A and B dims must agree");
 
   scalapackpp::scalapack_desc desc_a, desc_b;
   {
-  auto [Mloc, Nloc] = A_sca.dist().get_local_dims(N, N);
-  desc_a = A_sca.dist().descinit_noerror(N, N, Mloc);
+    auto [Mloc, Nloc] = A_sca.dist().get_local_dims(N, N);
+    desc_a = A_sca.dist().descinit_noerror(N, N, Mloc);
   }
 
   {
-  auto [Mloc, Nloc] = B_sca.dist().get_local_dims(N, NRHS);
-  desc_b = B_sca.dist().descinit_noerror(N, NRHS, Mloc);
+    auto [Mloc, Nloc] = B_sca.dist().get_local_dims(N, NRHS);
+    desc_b = B_sca.dist().descinit_noerror(N, NRHS, Mloc);
   }
 
-  auto info = scalapackpp::pposv( blacspp::Triangle::Lower, N, NRHS,
-    A_sca.local_mat().data(), 1, 1, desc_a, B_sca.local_mat().data(),
-    1, 1, desc_b );
+  auto info = scalapackpp::pposv(blacspp::Triangle::Lower, N, NRHS,
+                                 A_sca.local_mat().data(), 1, 1, desc_a,
+                                 B_sca.local_mat().data(), 1, 1, desc_b);
   if (info) throw std::runtime_error("Cholesky Solve Failed");
 
-  if( x_trange.rank() == 0 ) x_trange = B.trange();
+  if (x_trange.rank() == 0) x_trange = B.trange();
 
   world.gop.fence();
-  auto X = block_cyclic_to_array<Array>( B_sca, x_trange );
+  auto X = block_cyclic_to_array<Array>(B_sca, x_trange);
   world.gop.fence();
 
   return X;
 }
 
-
-
-
 template <typename Array>
-auto cholesky_lsolve( scalapackpp::TransposeFlag trans, 
-  const Array& A, const Array& B, size_t NB = 128, 
-  TiledRange l_trange = TiledRange(),
-  TiledRange x_trange = TiledRange() ) {
-
+auto cholesky_lsolve(scalapackpp::TransposeFlag trans, const Array& A,
+                     const Array& B, size_t NB = 128,
+                     TiledRange l_trange = TiledRange(),
+                     TiledRange x_trange = TiledRange()) {
   auto& world = A.world();
   /*
   if( world != B.world() ) {
-    throw std::runtime_error("A and B must be distributed on same MADWorld context");
+    throw std::runtime_error("A and B must be distributed on same MADWorld
+  context");
   }
   */
   auto world_comm = world.mpi.comm().Get_mpi_comm();
   blacspp::Grid grid = blacspp::Grid::square_grid(world_comm);
 
-  world.gop.fence(); // stage ScaLAPACK execution
-  auto A_sca = array_to_block_cyclic( A, grid, NB, NB );
-  auto B_sca = array_to_block_cyclic( B, grid, NB, NB );
-  world.gop.fence(); // stage ScaLAPACK execution
+  world.gop.fence();  // stage ScaLAPACK execution
+  auto A_sca = array_to_block_cyclic(A, grid, NB, NB);
+  auto B_sca = array_to_block_cyclic(B, grid, NB, NB);
+  world.gop.fence();  // stage ScaLAPACK execution
 
   auto [M, N] = A_sca.dims();
-  if( M != N )
-    throw std::runtime_error("A must be square for Cholesky Solve");
+  if (M != N) throw std::runtime_error("A must be square for Cholesky Solve");
 
   auto [B_N, NRHS] = B_sca.dims();
-  if( B_N != N )
-    throw std::runtime_error("A and B dims must agree");
-
+  if (B_N != N) throw std::runtime_error("A and B dims must agree");
 
   scalapackpp::scalapack_desc desc_a, desc_b;
   {
-  auto [Mloc, Nloc] = A_sca.dist().get_local_dims(N, N);
-  desc_a = A_sca.dist().descinit_noerror(N, N, Mloc);
+    auto [Mloc, Nloc] = A_sca.dist().get_local_dims(N, N);
+    desc_a = A_sca.dist().descinit_noerror(N, N, Mloc);
   }
 
   {
-  auto [Mloc, Nloc] = B_sca.dist().get_local_dims(N, NRHS);
-  desc_b = B_sca.dist().descinit_noerror(N, NRHS, Mloc);
+    auto [Mloc, Nloc] = B_sca.dist().get_local_dims(N, NRHS);
+    desc_b = B_sca.dist().descinit_noerror(N, NRHS, Mloc);
   }
 
-  auto info = scalapackpp::ppotrf( blacspp::Triangle::Lower, N,
-    A_sca.local_mat().data(), 1, 1, desc_a );
+  auto info = scalapackpp::ppotrf(blacspp::Triangle::Lower, N,
+                                  A_sca.local_mat().data(), 1, 1, desc_a);
   if (info) throw std::runtime_error("Cholesky Failed");
 
-  info = scalapackpp::ptrtrs( blacspp::Triangle::Lower, trans, 
-    blacspp::Diagonal::NonUnit, N, NRHS, A_sca.local_mat().data(), 1, 1, desc_a,
-    B_sca.local_mat().data(), 1, 1, desc_b );
+  info = scalapackpp::ptrtrs(blacspp::Triangle::Lower, trans,
+                             blacspp::Diagonal::NonUnit, N, NRHS,
+                             A_sca.local_mat().data(), 1, 1, desc_a,
+                             B_sca.local_mat().data(), 1, 1, desc_b);
   if (info) throw std::runtime_error("TRTRS Failed");
 
   // Zero out the upper triangle
-  detail::scalapack_zero_triangle( blacspp::Triangle::Upper, A_sca );
+  detail::scalapack_zero_triangle(blacspp::Triangle::Upper, A_sca);
 
-  if( l_trange.rank() == 0 ) l_trange = A.trange();
-  if( x_trange.rank() == 0 ) x_trange = B.trange();
+  if (l_trange.rank() == 0) l_trange = A.trange();
+  if (x_trange.rank() == 0) x_trange = B.trange();
 
   world.gop.fence();
-  auto L = block_cyclic_to_array<Array>( A_sca, l_trange );
-  auto X = block_cyclic_to_array<Array>( B_sca, x_trange );
+  auto L = block_cyclic_to_array<Array>(A_sca, l_trange);
+  auto X = block_cyclic_to_array<Array>(B_sca, x_trange);
   world.gop.fence();
 
   return std::tuple(L, X);
 }
 
-} // namespace TiledArray
+#else  // TILEDARRAY_HAS_SCALAPACK
 
-#endif // TILEDARRAY_HAS_SCALAPACK
-#endif // TILEDARRAY_MATH_SCALAPACK_H__INCLUDED
+namespace TiledArray::scalapack {
 
+template <typename Array>
+auto cholesky(const Array& A, size_t NB = 128,
+              TiledRange l_trange = TiledRange()) {
+  TA_EXCEPTION("TiledArray was built without ScaLAPACK.");
+}
+
+template <typename Array, bool RetL = false>
+auto cholesky_linv(const Array& A, size_t NB = 128,
+                   TiledRange l_trange = TiledRange()) {
+  TA_EXCEPTION("TiledArray was built without ScaLAPACK.");
+}
+
+template <typename Array>
+auto cholesky_solve(const Array& A, const Array& B, size_t NB = 128,
+                    TiledRange x_trange = TiledRange()) {
+  TA_EXCEPTION("TiledArray was built without ScaLAPACK.");
+}
+
+#endif  // TILEDARRAY_HAS_SCALAPACK
+
+}  // namespace TiledArray::scalapack
+#endif  // TILEDARRAY_MATH_SCALAPACK_H__INCLUDED

--- a/src/TiledArray/math/scalapack/chol.h
+++ b/src/TiledArray/math/scalapack/chol.h
@@ -282,19 +282,19 @@ auto cholesky_lsolve(scalapackpp::TransposeFlag trans, const Array& A,
 namespace TiledArray::scalapack {
 
 template <typename Array>
-auto cholesky(const Array& A, size_t NB = 128,
+Array cholesky(const Array& A, size_t NB = 128,
               TiledRange l_trange = TiledRange()) {
   TA_EXCEPTION("TiledArray was built without ScaLAPACK.");
 }
 
 template <typename Array, bool RetL = false>
-auto cholesky_linv(const Array& A, size_t NB = 128,
+Array cholesky_linv(const Array& A, size_t NB = 128,
                    TiledRange l_trange = TiledRange()) {
   TA_EXCEPTION("TiledArray was built without ScaLAPACK.");
 }
 
 template <typename Array>
-auto cholesky_solve(const Array& A, const Array& B, size_t NB = 128,
+Array cholesky_solve(const Array& A, const Array& B, size_t NB = 128,
                     TiledRange x_trange = TiledRange()) {
   TA_EXCEPTION("TiledArray was built without ScaLAPACK.");
 }

--- a/src/TiledArray/math/scalapack/heig.h
+++ b/src/TiledArray/math/scalapack/heig.h
@@ -167,13 +167,13 @@ auto heig(const Array& A, const Array& B, size_t NB = 128,
 namespace TiledArray::scalapack {
 
 template <typename Array>
-auto heig(const Array& A, size_t NB = 128,
+std::tuple<Array, Array> heig(const Array& A, size_t NB = 128,
           TiledRange evec_trange = TiledRange()) {
   TA_EXCEPTION("TiledArray was built without ScaLAPACK.");
 }
 
 template <typename Array>
-auto heig(const Array& A, const Array& B, size_t NB = 128,
+std::tuple<Array, Array> heig(const Array& A, const Array& B, size_t NB = 128,
           TiledRange evec_trange = TiledRange()) {
   TA_EXCEPTION("TiledArray was built without ScaLAPACK.");
 }

--- a/src/TiledArray/math/scalapack/heig.h
+++ b/src/TiledArray/math/scalapack/heig.h
@@ -162,7 +162,7 @@ auto heig(const Array& A, const Array& B, size_t NB = 128,
 
 } // namespace TiledArray::scalapack
 
-#endif // TILEDARRAY_HAS_SCALAPACK
+#else // TILEDARRAY_HAS_SCALAPACK
 
 namespace TiledArray::scalapack {
 
@@ -180,4 +180,5 @@ auto heig(const Array& A, const Array& B, size_t NB = 128,
 
 } // namespace TiledArray::scalapack
 
+#endif // TILEDARRAY_HAS_SCALAPACK
 #endif // TILEDARRAY_MATH_SCALAPACK_H__INCLUDED

--- a/src/TiledArray/math/scalapack/heig.h
+++ b/src/TiledArray/math/scalapack/heig.h
@@ -33,8 +33,7 @@
 #include <scalapackpp/eigenvalue_problem/sevp.hpp>
 #include <scalapackpp/eigenvalue_problem/gevp.hpp>
 
-namespace TiledArray {
-namespace scalapack {
+namespace TiledArray::scalapack {
 /**
  *  @brief Solve the standard eigenvalue problem with ScaLAPACK
  *
@@ -160,8 +159,25 @@ auto heig(const Array& A, const Array& B, size_t NB = 128,
 
   return std::tuple(evals, evecs_ta);
 }
-}
-} // namespace TiledArray
+
+} // namespace TiledArray::scalapack
 
 #endif // TILEDARRAY_HAS_SCALAPACK
+
+namespace TiledArray::scalapack {
+
+template <typename Array>
+auto heig(const Array& A, size_t NB = 128,
+          TiledRange evec_trange = TiledRange()) {
+  TA_EXCEPTION("TiledArray was built without ScaLAPACK.");
+}
+
+template <typename Array>
+auto heig(const Array& A, const Array& B, size_t NB = 128,
+          TiledRange evec_trange = TiledRange()) {
+  TA_EXCEPTION("TiledArray was built without ScaLAPACK.");
+}
+
+} // namespace TiledArray::scalapack
+
 #endif // TILEDARRAY_MATH_SCALAPACK_H__INCLUDED

--- a/src/TiledArray/math/scalapack/heig.h
+++ b/src/TiledArray/math/scalapack/heig.h
@@ -167,13 +167,15 @@ auto heig(const Array& A, const Array& B, size_t NB = 128,
 namespace TiledArray::scalapack {
 
 template <typename Array>
-std::tuple<Array, Array> heig(const Array& A, size_t NB = 128,
+std::tuple<std::vector<typename Array::numeric_type>, Array>
+heig(const Array& A, size_t NB = 128,
           TiledRange evec_trange = TiledRange()) {
   TA_EXCEPTION("TiledArray was built without ScaLAPACK.");
 }
 
 template <typename Array>
-std::tuple<Array, Array> heig(const Array& A, const Array& B, size_t NB = 128,
+std::tuple<std::vector<typename Array::numeric_type>, Array>
+heig(const Array& A, const Array& B, size_t NB = 128,
           TiledRange evec_trange = TiledRange()) {
   TA_EXCEPTION("TiledArray was built without ScaLAPACK.");
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -110,6 +110,7 @@ set(ta_test_src_files  ta_test.cpp
     t_tot_tot_contract_.cpp
     tot_tot_tot_contract_.cpp
     einsum.cpp
+    lapack.cpp
 )
 
 if(CUDA_FOUND)

--- a/tests/lapack.cpp
+++ b/tests/lapack.cpp
@@ -62,10 +62,10 @@ BOOST_AUTO_TEST_CASE(two_by_two) {
   auto& world = get_default_world();
   TiledRange trange{{0, 1, 2}, {0, 1, 2}};
   TSpArrayD a(world, trange, {{1.00, 1.00}, {1.00, 2.00}});
-  auto ainv = lapack::cholesky_linv(a);
-  std::cout << ainv << std::endl;
+  auto linv = lapack::cholesky_linv(a);
+  std::cout << linv << std::endl;
 
-  TSpArrayD ainv_corr(world, trange, {{2.0, -1.0}, {-1.0, 1.0}});
+  TSpArrayD ainv_corr(world, trange, {{1.0, 0.0}, {-1.0, 1.0}});
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/lapack.cpp
+++ b/tests/lapack.cpp
@@ -1,4 +1,5 @@
 #include "tiledarray.h"
+#include "TiledArray/math/lapack/chol.h"
 #include "TiledArray/math/lapack/heig.h"
 #include "unit_test_config.h"
 
@@ -15,6 +16,9 @@ BOOST_AUTO_TEST_CASE(two_by_two) {
   TSpArrayD eval_corr(world, TiledRange{{0, 1, 2}}, {-1.08645907, 10.20645907});
   TSpArrayD evec_corr(world, trange, {{-0.89155766,  0.4529072},
                                       {0.4529072 ,  0.89155766}});
+
+  std::cout << eval << std::endl;
+  std::cout << evecs << std::endl;
 }
 
 BOOST_AUTO_TEST_SUITE_END()
@@ -33,6 +37,35 @@ BOOST_AUTO_TEST_CASE(two_by_two) {
                                       {0.6484553, 0.95542611}});
   std::cout << eval << std::endl;
   std::cout << evecs << std::endl;
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+
+BOOST_AUTO_TEST_SUITE(chol)
+
+BOOST_AUTO_TEST_CASE(two_by_two) {
+  auto& world = get_default_world();
+  TiledRange trange{{0, 1, 2}, {0, 1, 2}};
+  TSpArrayD a(world, trange, {{1.00, 1.00}, {1.00, 2.00}});
+  auto L = lapack::cholesky(a);
+  std::cout << L << std::endl;
+
+  TSpArrayD L_corr(world, trange, {{1.0, 0.0}, {1.0, 1.0}});
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE(chol_inv)
+
+BOOST_AUTO_TEST_CASE(two_by_two) {
+  auto& world = get_default_world();
+  TiledRange trange{{0, 1, 2}, {0, 1, 2}};
+  TSpArrayD a(world, trange, {{1.00, 1.00}, {1.00, 2.00}});
+  auto ainv = lapack::cholesky_linv(a);
+  std::cout << ainv << std::endl;
+
+  TSpArrayD ainv_corr(world, trange, {{2.0, -1.0}, {-1.0, 1.0}});
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/lapack.cpp
+++ b/tests/lapack.cpp
@@ -1,0 +1,38 @@
+#include "tiledarray.h"
+#include "TiledArray/math/lapack/heig.h"
+#include "unit_test_config.h"
+
+using namespace TiledArray;
+
+BOOST_AUTO_TEST_SUITE(heig_orthogonal)
+
+BOOST_AUTO_TEST_CASE(two_by_two) {
+  auto& world = get_default_world();
+  TiledRange trange{{0, 1, 2}, {0, 1, 2}};
+  TSpArrayD a(world, trange, {{1.23, 4.56}, {4.56, 7.89}});
+  auto [eval, evecs] = lapack::heig(a);
+
+  TSpArrayD eval_corr(world, TiledRange{{0, 1, 2}}, {-1.08645907, 10.20645907});
+  TSpArrayD evec_corr(world, trange, {{-0.89155766,  0.4529072},
+                                      {0.4529072 ,  0.89155766}});
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE(heig_general)
+
+BOOST_AUTO_TEST_CASE(two_by_two) {
+  auto& world = get_default_world();
+  TiledRange trange{{0, 1, 2}, {0, 1, 2}};
+  TSpArrayD a(world, trange, {{1.23, 4.56}, {4.56, 7.89}});
+  TSpArrayD b(world, trange, {{1.00, 0.50}, {0.50, 1.00}});
+  auto [eval, evecs] = lapack::heig(a, b);
+
+  TSpArrayD eval_corr(world, TiledRange{{0, 1, 2}}, {-1.86171399,  7.94171399});
+  TSpArrayD evec_corr(world, trange, {{-1.15165094, 0.0838657},
+                                      {0.6484553, 0.95542611}});
+  std::cout << eval << std::endl;
+  std::cout << evecs << std::endl;
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
As TA stands with @wavefunction91 's PR it only supports linear algebra with ScaLAPACK. While this is likely to be what TA needs most of the time (it is a distributed tensor library after all) there are use cases (DLPNO for example) where we need to do linear algebra on replicated tensors; furthermore, since ScaLAPACK is an optional dependency TA needs a fallback plan for the linear algebra APIs when the user didn't build ScaLAPACK. This PR:

- slightly refactors code in the `src/TiledArray/math`directory
  - APIs for linear algebra are now stored in `src/TiledArray/math/linear_algebra.h`
  - Backends are now in their own namespaces and the API in the `TiledArray` namespace switches between implementations as appropriate
    - users can always force a backend by namespace prefixing the call, *e.g.* `scalapack::heigh`.
  - reduced the number of files where `#ifdef` logic occurs for scalapack
- adds `heig` with LAPACK backend for standard and generalized eigenvalue problems

TODO:
  - cholesky_linv
  - anything else needed to get SCF to run

Note: I'm only writing this PR to get SCF to run. That said, @evaleev I think the quality and content of this PR is worth expanding on and adding to TA proper, but fleshing it out is not a priority on my trajectory (nor is optimizing the implementations). Furthermore, this PR is designed to work off the `developer` branch of NWX's TA fork (a mirror of TA master that has @wavefunction91's PR merged and my ToT PRs merged) so merging it into TA proper may be difficult.
