### PR TITLE
[WIP] Add t_t_t kernel option to einsum

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -106,6 +106,9 @@ TiledArray/external/btas.h
 TiledArray/math/blas.h
 TiledArray/math/eigen.h
 TiledArray/math/gemm_helper.h
+TiledArray/math/lapack/chol.h
+TiledArray/math/lapack/heig.h
+TiledArray/math/linear_algebra.h
 TiledArray/math/outer.h
 TiledArray/math/parallel_gemm.h
 TiledArray/math/partial_reduce.h

--- a/src/TiledArray/conversions/eigen.h
+++ b/src/TiledArray/conversions/eigen.h
@@ -576,7 +576,7 @@ inline A row_major_buffer_to_array(
   typedef Eigen::Matrix<typename A::value_type::value_type, Eigen::Dynamic,
                         Eigen::Dynamic, Eigen::RowMajor>
       matrix_type;
-  return eigen_to_array(
+  return eigen_to_array<A>(
       world, trange,
       Eigen::Map<const matrix_type, Eigen::AutoAlign>(buffer, m, n),
       replicated);
@@ -638,7 +638,7 @@ inline A column_major_buffer_to_array(
   typedef Eigen::Matrix<typename A::value_type::value_type, Eigen::Dynamic,
                         Eigen::Dynamic, Eigen::ColMajor>
       matrix_type;
-  return eigen_to_array(
+  return eigen_to_array<A>(
       world, trange,
       Eigen::Map<const matrix_type, Eigen::AutoAlign>(buffer, m, n),
       replicated);

--- a/src/TiledArray/conversions/make_array.h
+++ b/src/TiledArray/conversions/make_array.h
@@ -26,8 +26,10 @@
 #ifndef TILEDARRAY_CONVERSIONS_MAKE_ARRAY_H__INCLUDED
 #define TILEDARRAY_CONVERSIONS_MAKE_ARRAY_H__INCLUDED
 
-#include <TiledArray/external/madness.h>
-#include <TiledArray/type_traits.h>
+#include "TiledArray/external/madness.h"
+#include "TiledArray/shape.h"
+#include "TiledArray/type_traits.h"
+
 
 /// Forward declarations
 namespace Eigen {

--- a/src/TiledArray/expressions/contraction_helpers.h
+++ b/src/TiledArray/expressions/contraction_helpers.h
@@ -20,6 +20,7 @@
 #ifndef TILEDARRAY_EXPRESSIONS_CONTRACTION_HELPERS_H__INCLUDED
 #define TILEDARRAY_EXPRESSIONS_CONTRACTION_HELPERS_H__INCLUDED
 
+#include "TiledArray/conversions/make_array.h"
 #include "TiledArray/expressions/tsr_expr.h"
 #include "TiledArray/expressions/variable_list.h"
 #include "TiledArray/tensor/tensor.h"
@@ -563,7 +564,7 @@ void einsum(TsrExpr<ResultType, true> out,
       trange_from_annotation(bound_vars, lhs_ovars, rhs_ovars, ltensor, rtensor);
 
 
-  auto l = [=](auto& tile, const TA::Range& r){
+  auto l = [=](auto& tile, const Range& r){
 
     const auto oidx =
         orange.tiles_range().idx(orange.element_to_tile(r.lobound()));

--- a/src/TiledArray/expressions/contraction_helpers.h
+++ b/src/TiledArray/expressions/contraction_helpers.h
@@ -595,6 +595,11 @@ void einsum(TsrExpr<ResultType, true> out,
             tile = kernels::tot_t_tot_contract_(ovars, lvars, rvars, ltile, rtile);
           else
             tile += kernels::tot_t_tot_contract_(ovars, lvars, rvars, ltile, rtile);
+        } else if constexpr(!out_is_tot && !lhs_is_tot && !rhs_is_tot){
+          if(tile.empty())
+            tile = kernels::t_t_t_contract_(ovars, lvars, rvars, ltile, rtile);
+          else
+            tile += kernels::t_t_t_contract_(ovars, lvars, rvars, ltile, rtile);
         } else {
           TA_ASSERT(false);  // Your kernel isn't supported
         }

--- a/src/TiledArray/math/lapack/chol.h
+++ b/src/TiledArray/math/lapack/chol.h
@@ -1,7 +1,7 @@
 #ifndef TILEDARRAY_MATH_LAPACK_CHOL_H__INCLUDED
 #define TILEDARRAY_MATH_LAPACK_CHOL_H__INCLUDED
 #include "TiledArray/conversions/eigen.h"
-
+#include <madness/tensor/clapack.h>
 namespace TiledArray::lapack {
 namespace detail {
 

--- a/src/TiledArray/math/lapack/chol.h
+++ b/src/TiledArray/math/lapack/chol.h
@@ -25,7 +25,11 @@ auto cholesky_(const Array& A) {
   int nrows = A_eigen.rows();
   int ncols = A_eigen.cols();
   int info;
-  potrf_("L", &nrows, A_eigen.data(), &ncols, &info);
+  if constexpr (std::is_same_v<numeric_type, double>) {
+    dpotrf("L", &nrows, A_eigen.data(), &ncols, &info);
+  } else {
+    TA_EXCEPTION("Your numeric type is not hooked up at the moment");
+  }
 
   // I think I need to zero out the upper triangle, but I'm not 100% sure...
   for (auto i = 0; i < nrows; ++i)
@@ -54,8 +58,11 @@ auto cholesky_linv(const Array& A) {
   int nrows = L_eigen.rows();
   int ncols = L_eigen.cols();
   int info;
-  trtri_("L", "N", &nrows, L_eigen.data(), &ncols, &info);
-
+  if constexpr(std::is_same_v<numeric_type, double>){
+    dtrtri("L", "N", &nrows, L_eigen.data(), &ncols, &info);
+  } else {
+    TA_EXCEPTION("Your numeric type is not hooked up at the moment");
+  }
   for(auto i = 0; i < nrows; ++i)
     for(auto j = i + 1; j < ncols; ++j) L_eigen(i,j) = 0.0;
 

--- a/src/TiledArray/math/lapack/chol.h
+++ b/src/TiledArray/math/lapack/chol.h
@@ -1,0 +1,81 @@
+#ifndef TILEDARRAY_MATH_LAPACK_CHOL_H__INCLUDED
+#define TILEDARRAY_MATH_LAPACK_CHOL_H__INCLUDED
+#include "TiledArray/conversions/eigen.h"
+
+namespace TiledArray::lapack {
+namespace detail {
+
+/// \brief Peforms Cholesky, but does not convert back to a DistArray
+///
+/// Cholesky decomposition is the first step of `cholesky_linv` and
+/// `cholesky_solve`, but if we try to write them in terms of `cholesky` we'll
+/// end up creating a DistArray with L, only to have to take it apart again.
+/// This function is the guts of the `cholesky` function without the conversion
+/// to a DistArray.
+///
+/// @tparam Array
+/// @param A
+/// @return
+template <typename Array>
+auto cholesky_(const Array& A) {
+  using tensor_type = Array;
+  using numeric_type = typename tensor_type::numeric_type;
+
+  auto A_eigen = array_to_eigen(A);
+  int nrows = A_eigen.rows();
+  int ncols = A_eigen.cols();
+  int info;
+  if constexpr (std::is_same_v<numeric_type, double>) {
+    dpotrf("L", &nrows, A_eigen.data(), &ncols, &info);
+  } else {
+    TA_EXCEPTION("Your numeric type is not hooked up at the moment");
+  }
+
+  // I think I need to zero out the upper triangle, but I'm not 100% sure...
+  for (auto i = 0; i < nrows; ++i)
+    for (auto j = i + 1; j < ncols; ++j) A_eigen(i, j) = 0.0;
+  return A_eigen;
+}
+
+} // namespace detail
+
+
+template <typename Array>
+auto cholesky(const Array& A) {
+  using tensor_type = Array;
+  auto L_eigen = detail::cholesky_(A);
+  const auto nrows = A.elements_range().upbound(0);
+  return column_major_buffer_to_array<tensor_type>(
+      A.world(), A.trange(), L_eigen.data(), nrows, nrows);
+}
+
+template<typename Array>
+auto cholesky_linv(const Array& A) {
+  using tensor_type = Array;
+  using numeric_type = typename tensor_type::numeric_type;
+
+  auto L_eigen = detail::cholesky_(A);
+  int nrows = L_eigen.rows();
+  int ncols = L_eigen.cols();
+  int info;
+  if constexpr(std::is_same_v<numeric_type, double>){
+    dtrtri("L", "N", &nrows, L_eigen.data(), &ncols, &info);
+  } else {
+    TA_EXCEPTION("Your numeric type is not hooked up at the moment");
+  }
+  for(auto i = 0; i < nrows; ++i)
+    for(auto j = i + 1; j < ncols; ++j) L_eigen(i,j) = 0.0;
+
+  return column_major_buffer_to_array<tensor_type>(
+      A.world(), A.trange(), L_eigen.data(), nrows, ncols);
+}
+
+template<typename Array>
+auto cholesky_solve(const Array& A, const Array& B) {
+  TA_EXCEPTION("LAPACK version is not implemented");
+}
+
+
+} // namespace TiledArray::lapack
+
+#endif // TILEDARRAY_MATH_LAPACK_CHOL_H__INCLUDED

--- a/src/TiledArray/math/lapack/chol.h
+++ b/src/TiledArray/math/lapack/chol.h
@@ -25,11 +25,7 @@ auto cholesky_(const Array& A) {
   int nrows = A_eigen.rows();
   int ncols = A_eigen.cols();
   int info;
-  if constexpr (std::is_same_v<numeric_type, double>) {
-    dpotrf_("L", &nrows, A_eigen.data(), &ncols, &info);
-  } else {
-    TA_EXCEPTION("Your numeric type is not hooked up at the moment");
-  }
+  potrf_("L", &nrows, A_eigen.data(), &ncols, &info);
 
   // I think I need to zero out the upper triangle, but I'm not 100% sure...
   for (auto i = 0; i < nrows; ++i)
@@ -58,11 +54,8 @@ auto cholesky_linv(const Array& A) {
   int nrows = L_eigen.rows();
   int ncols = L_eigen.cols();
   int info;
-  if constexpr(std::is_same_v<numeric_type, double>){
-    dtrtri_("L", "N", &nrows, L_eigen.data(), &ncols, &info);
-  } else {
-    TA_EXCEPTION("Your numeric type is not hooked up at the moment");
-  }
+  trtri_("L", "N", &nrows, L_eigen.data(), &ncols, &info);
+
   for(auto i = 0; i < nrows; ++i)
     for(auto j = i + 1; j < ncols; ++j) L_eigen(i,j) = 0.0;
 

--- a/src/TiledArray/math/lapack/chol.h
+++ b/src/TiledArray/math/lapack/chol.h
@@ -26,7 +26,7 @@ auto cholesky_(const Array& A) {
   int ncols = A_eigen.cols();
   int info;
   if constexpr (std::is_same_v<numeric_type, double>) {
-    dpotrf("L", &nrows, A_eigen.data(), &ncols, &info);
+    dpotrf_("L", &nrows, A_eigen.data(), &ncols, &info);
   } else {
     TA_EXCEPTION("Your numeric type is not hooked up at the moment");
   }
@@ -59,7 +59,7 @@ auto cholesky_linv(const Array& A) {
   int ncols = L_eigen.cols();
   int info;
   if constexpr(std::is_same_v<numeric_type, double>){
-    dtrtri("L", "N", &nrows, L_eigen.data(), &ncols, &info);
+    dtrtri_("L", "N", &nrows, L_eigen.data(), &ncols, &info);
   } else {
     TA_EXCEPTION("Your numeric type is not hooked up at the moment");
   }

--- a/src/TiledArray/math/lapack/heig.h
+++ b/src/TiledArray/math/lapack/heig.h
@@ -22,11 +22,11 @@ auto heig(const Array& A) {
   std::vector<numeric_type> evals(nrows);
 
   if constexpr(std::is_same_v<numeric_type, double>) {
-    dsyev("V", "U", &nrows, A_eigen.data(), &ncols, evals.data(),
+    dsyev_("V", "U", &nrows, A_eigen.data(), &ncols, evals.data(),
           work.data(), &lwork, &info);
     lwork = work[0];
     work = std::vector<numeric_type>(lwork);
-    dsyev("V", "U", &nrows, A_eigen.data(), &ncols, evals.data(),
+    dsyev_("V", "U", &nrows, A_eigen.data(), &ncols, evals.data(),
           work.data(), &lwork, &info);
   }
   else {
@@ -65,7 +65,7 @@ auto heig(const Array& A, const Array& B) {
   if constexpr(std::is_same_v<numeric_type, double>) {
     int one = 1;
     // First call gets optimial sizes
-    dsygvd(&one, "V", "U", &nrows, A_eigen.data(), &ncols, B_eigen.data(),
+    dsygvd_(&one, "V", "U", &nrows, A_eigen.data(), &ncols, B_eigen.data(),
            &ncols, evals.data(), work.data(), &lwork, iwork.data(),
            &liwork, &info);
     lwork = work[0];
@@ -73,7 +73,7 @@ auto heig(const Array& A, const Array& B) {
     work = std::vector<numeric_type>(lwork);
     iwork = std::vector<int>(liwork);
     // This call does the real work
-    dsygvd(&one, "V", "U", &nrows, A_eigen.data(), &ncols, B_eigen.data(),
+    dsygvd_(&one, "V", "U", &nrows, A_eigen.data(), &ncols, B_eigen.data(),
            &ncols, evals.data(), work.data(), &lwork, iwork.data(),
            &liwork, &info);
 

--- a/src/TiledArray/math/lapack/heig.h
+++ b/src/TiledArray/math/lapack/heig.h
@@ -1,0 +1,97 @@
+#ifndef TILEDARRAY_MATH_LAPACK_HEIG_H__INCLUDED
+#define TILEDARRAY_MATH_LAPACK_HEIG_H__INCLUDED
+#include "TiledArray/conversions/eigen.h"
+
+namespace TiledArray::lapack {
+
+template <typename Array>
+auto heig(const Array& A) {
+  using tensor_type = Array;
+  using numeric_type = typename tensor_type::numeric_type;
+  using tile_type = typename tensor_type::value_type;
+
+  auto& world = A.world();
+
+  auto A_eigen = array_to_eigen(A);
+  const int nrows = A_eigen.rows();
+  const int ncols = A_eigen.cols();
+
+  int lwork = -1;
+  int info;
+  std::vector<numeric_type> work(1);
+  std::vector<numeric_type> evals(nrows);
+
+  if constexpr(std::is_same_v<numeric_type, double>) {
+    dsyev("V", "U", &nrows, A_eigen.data(), &ncols, evals.data(),
+          work.data(), &lwork, &info);
+    lwork = work[0];
+    work = std::vector<numeric_type>(lwork);
+    dsyev("V", "U", &nrows, A_eigen.data(), &ncols, evals.data(),
+          work.data(), &lwork, &info);
+  }
+  else {
+    TA_EXCEPTION("Your numeric type is not hooked up at the moment");
+  }
+
+  const auto& matrix_trange = A.trange();
+  TiledRange vector_trange{matrix_trange.dim(0)};
+
+  auto evecs =
+    column_major_buffer_to_array<tensor_type>(world, matrix_trange,
+                                                A_eigen.data(), nrows, ncols);
+  return std::tuple(evals, evecs);
+}
+
+template <typename Array>
+auto heig(const Array& A, const Array& B) {
+  using tensor_type = Array;
+  using numeric_type = typename tensor_type::numeric_type;
+  using tile_type = typename tensor_type::value_type;
+
+  auto& world = A.world();
+
+  auto A_eigen = array_to_eigen(A);
+  auto B_eigen = array_to_eigen(B);
+  const int nrows = A_eigen.rows();
+  const int ncols = A_eigen.cols();
+
+  int lwork = -1;
+  int liwork = -1;
+  int info;
+  std::vector<numeric_type> evals(nrows);
+  std::vector<numeric_type> work(1);
+  std::vector<int> iwork(1);
+
+  if constexpr(std::is_same_v<numeric_type, double>) {
+    int one = 1;
+    // First call gets optimial sizes
+    dsygvd(&one, "V", "U", &nrows, A_eigen.data(), &ncols, B_eigen.data(),
+           &ncols, evals.data(), work.data(), &lwork, iwork.data(),
+           &liwork, &info);
+    lwork = work[0];
+    liwork = iwork[0];
+    work = std::vector<numeric_type>(lwork);
+    iwork = std::vector<int>(liwork);
+    // This call does the real work
+    dsygvd(&one, "V", "U", &nrows, A_eigen.data(), &ncols, B_eigen.data(),
+           &ncols, evals.data(), work.data(), &lwork, iwork.data(),
+           &liwork, &info);
+
+  }
+  else {
+    TA_EXCEPTION("Your numeric type is not hooked up at the moment");
+  }
+
+  const auto& matrix_trange = A.trange();
+  TiledRange vector_trange{matrix_trange.dim(0)};
+
+  auto evecs =
+      column_major_buffer_to_array<tensor_type>(world, matrix_trange,
+                                                A_eigen.data(), nrows, ncols);
+
+  return std::tuple(evals, evecs);
+}
+
+} // namespace TiledArray::lapack
+
+#endif

--- a/src/TiledArray/math/lapack/heig.h
+++ b/src/TiledArray/math/lapack/heig.h
@@ -21,17 +21,12 @@ auto heig(const Array& A) {
   std::vector<numeric_type> work(1);
   std::vector<numeric_type> evals(nrows);
 
-  if constexpr(std::is_same_v<numeric_type, double>) {
-    dsyev_("V", "U", &nrows, A_eigen.data(), &ncols, evals.data(),
-          work.data(), &lwork, &info);
-    lwork = work[0];
-    work = std::vector<numeric_type>(lwork);
-    dsyev_("V", "U", &nrows, A_eigen.data(), &ncols, evals.data(),
-          work.data(), &lwork, &info);
-  }
-  else {
-    TA_EXCEPTION("Your numeric type is not hooked up at the moment");
-  }
+  syev_("V", "U", &nrows, A_eigen.data(), &ncols, evals.data(),
+        work.data(), &lwork, &info);
+  lwork = work[0];
+  work = std::vector<numeric_type>(lwork);
+  syev_("V", "U", &nrows, A_eigen.data(), &ncols, evals.data(),
+        work.data(), &lwork, &info);
 
   const auto& matrix_trange = A.trange();
   TiledRange vector_trange{matrix_trange.dim(0)};
@@ -62,25 +57,20 @@ auto heig(const Array& A, const Array& B) {
   std::vector<numeric_type> work(1);
   std::vector<int> iwork(1);
 
-  if constexpr(std::is_same_v<numeric_type, double>) {
-    int one = 1;
-    // First call gets optimial sizes
-    dsygvd_(&one, "V", "U", &nrows, A_eigen.data(), &ncols, B_eigen.data(),
-           &ncols, evals.data(), work.data(), &lwork, iwork.data(),
-           &liwork, &info);
-    lwork = work[0];
-    liwork = iwork[0];
-    work = std::vector<numeric_type>(lwork);
-    iwork = std::vector<int>(liwork);
-    // This call does the real work
-    dsygvd_(&one, "V", "U", &nrows, A_eigen.data(), &ncols, B_eigen.data(),
-           &ncols, evals.data(), work.data(), &lwork, iwork.data(),
-           &liwork, &info);
+  int one = 1;
+  // First call gets optimial sizes
+  sygvd_(&one, "V", "U", &nrows, A_eigen.data(), &ncols, B_eigen.data(),
+         &ncols, evals.data(), work.data(), &lwork, iwork.data(),
+         &liwork, &info);
+  lwork = work[0];
+  liwork = iwork[0];
+  work = std::vector<numeric_type>(lwork);
+  iwork = std::vector<int>(liwork);
 
-  }
-  else {
-    TA_EXCEPTION("Your numeric type is not hooked up at the moment");
-  }
+  // This call does the real work
+  sygvd_(&one, "V", "U", &nrows, A_eigen.data(), &ncols, B_eigen.data(),
+         &ncols, evals.data(), work.data(), &lwork, iwork.data(),
+         &liwork, &info);
 
   const auto& matrix_trange = A.trange();
   TiledRange vector_trange{matrix_trange.dim(0)};

--- a/src/TiledArray/math/lapack/heig.h
+++ b/src/TiledArray/math/lapack/heig.h
@@ -1,7 +1,7 @@
 #ifndef TILEDARRAY_MATH_LAPACK_HEIG_H__INCLUDED
 #define TILEDARRAY_MATH_LAPACK_HEIG_H__INCLUDED
 #include "TiledArray/conversions/eigen.h"
-
+#include <madness/tensor/clapack.h>
 namespace TiledArray::lapack {
 
 template <typename Array>

--- a/src/TiledArray/math/lapack/heig.h
+++ b/src/TiledArray/math/lapack/heig.h
@@ -21,12 +21,17 @@ auto heig(const Array& A) {
   std::vector<numeric_type> work(1);
   std::vector<numeric_type> evals(nrows);
 
-  syev_("V", "U", &nrows, A_eigen.data(), &ncols, evals.data(),
-        work.data(), &lwork, &info);
-  lwork = work[0];
-  work = std::vector<numeric_type>(lwork);
-  syev_("V", "U", &nrows, A_eigen.data(), &ncols, evals.data(),
-        work.data(), &lwork, &info);
+  if constexpr(std::is_same_v<numeric_type, double>) {
+    dsyev("V", "U", &nrows, A_eigen.data(), &ncols, evals.data(),
+          work.data(), &lwork, &info);
+    lwork = work[0];
+    work = std::vector<numeric_type>(lwork);
+    dsyev("V", "U", &nrows, A_eigen.data(), &ncols, evals.data(),
+          work.data(), &lwork, &info);
+  }
+  else {
+    TA_EXCEPTION("Your numeric type is not hooked up at the moment");
+  }
 
   const auto& matrix_trange = A.trange();
   TiledRange vector_trange{matrix_trange.dim(0)};
@@ -57,20 +62,25 @@ auto heig(const Array& A, const Array& B) {
   std::vector<numeric_type> work(1);
   std::vector<int> iwork(1);
 
-  int one = 1;
-  // First call gets optimial sizes
-  sygvd_(&one, "V", "U", &nrows, A_eigen.data(), &ncols, B_eigen.data(),
-         &ncols, evals.data(), work.data(), &lwork, iwork.data(),
-         &liwork, &info);
-  lwork = work[0];
-  liwork = iwork[0];
-  work = std::vector<numeric_type>(lwork);
-  iwork = std::vector<int>(liwork);
+  if constexpr(std::is_same_v<numeric_type, double>) {
+    int one = 1;
+    // First call gets optimial sizes
+    dsygvd(&one, "V", "U", &nrows, A_eigen.data(), &ncols, B_eigen.data(),
+           &ncols, evals.data(), work.data(), &lwork, iwork.data(),
+           &liwork, &info);
+    lwork = work[0];
+    liwork = iwork[0];
+    work = std::vector<numeric_type>(lwork);
+    iwork = std::vector<int>(liwork);
+    // This call does the real work
+    dsygvd(&one, "V", "U", &nrows, A_eigen.data(), &ncols, B_eigen.data(),
+           &ncols, evals.data(), work.data(), &lwork, iwork.data(),
+           &liwork, &info);
 
-  // This call does the real work
-  sygvd_(&one, "V", "U", &nrows, A_eigen.data(), &ncols, B_eigen.data(),
-         &ncols, evals.data(), work.data(), &lwork, iwork.data(),
-         &liwork, &info);
+  }
+  else {
+    TA_EXCEPTION("Your numeric type is not hooked up at the moment");
+  }
 
   const auto& matrix_trange = A.trange();
   TiledRange vector_trange{matrix_trange.dim(0)};

--- a/src/TiledArray/math/linear_algebra.h
+++ b/src/TiledArray/math/linear_algebra.h
@@ -1,0 +1,35 @@
+#ifndef TILEDARRAY_MATH_LINEAR_ALGEBRA_H__INCLUDED
+#define TILEDARRAY_MATH_LINEAR_ALGEBRA_H__INCLUDED
+#include "TiledArray/math/scalapack.h"
+#include "TiledArray/math/lapack/chol.h"
+#include "TiledArray/math/lapack/heig.h"
+#include "TiledArray/config.h"
+
+namespace TiledArray {
+
+template<typename Array>
+auto heig(const Array& A) {
+  return detail::use_scalapack(A) ? scalapack::heig(A) : lapack::heig(A);
+}
+
+template<typename Array>
+auto heig(const Array& A, const Array& B) {
+  const bool scalapack = detail::use_scalapack(A, B);
+  return scalapack ? scalapack::heig(A, B) : lapack::heig(A, B);
+}
+
+template<typename Array>
+auto cholesky(const Array& A) {
+  const bool scalapack = detail::use_scalapack(A);
+  return scalapack? scalapack::cholesky(A) : lapack::cholesky(A);
+}
+
+template<typename Array>
+auto cholesky_linv(const Array& A) {
+  const bool scalapack = detail::use_scalapack(A);
+  return scalapack ? scalapack::cholesky_linv(A) : lapack::cholesky_linv(A);
+}
+
+}
+
+#endif // TILEDARRAY_MATH_LINEAR_ALGEBRA_H__INCLUDED

--- a/src/TiledArray/math/scalapack.h
+++ b/src/TiledArray/math/scalapack.h
@@ -25,10 +25,32 @@
 #ifndef TILEDARRAY_MATH_SCALAPACK_H__INCLUDED
 #define TILEDARRAY_MATH_SCALAPACK_H__INCLUDED
 
-#if TILEDARRAY_HAS_SCALAPACK
-
 #include <TiledArray/math/scalapack/heig.h>
 #include <TiledArray/math/scalapack/chol.h>
+
+namespace TiledArray::detail {
+
+/// \brief Determines whether we should use the ScaLAPACK implementation of the
+///        linear algebra routine or not
+///
+/// @tparam TensorTypes The type of the tensors we are performing linear algebra
+///                     on. Expected to be TA::DistArray instances.
+/// @param ts
+/// @return
+template<typename...TensorTypes>
+bool use_scalapack(TensorTypes&&...ts) {
+  // TODO: Check if tensor ts are distributed, if not don't use SCALAPACK
+#if TILEDARRAY_HAS_SCALAPACK
+  return true;
+#else
+  return false;
+#endif
+}
+
+} //namespace TiledArray::detail
+
+#if TILEDARRAY_HAS_SCALAPACK
+
 #include <TiledArray/math/scalapack/svd.h>
 #include <TiledArray/math/scalapack/lu.h>
 

--- a/src/TiledArray/math/scalapack/chol.h
+++ b/src/TiledArray/math/scalapack/chol.h
@@ -32,11 +32,11 @@
 #include <TiledArray/math/scalapack/util.h>
 
 #include <scalapackpp/factorizations/potrf.hpp>
-#include <scalapackpp/matrix_inverse/trtri.hpp>
 #include <scalapackpp/linear_systems/posv.hpp>
 #include <scalapackpp/linear_systems/trtrs.hpp>
+#include <scalapackpp/matrix_inverse/trtri.hpp>
 
-namespace TiledArray {
+namespace TiledArray::scalapack {
 
 /**
  *  @brief Compute the Cholesky factorization of a HPD rank-2 tensor
@@ -51,54 +51,45 @@ namespace TiledArray {
  *
  *  @param[in] A           Input array to be diagonalized. Must be rank-2
  *  @param[in] NB          ScaLAPACK blocking factor. Defaults to 128
- *  @param[in] l_trange    TiledRange for resulting Cholesky factor. If left empty,
- *                         will default to array.trange()
+ *  @param[in] l_trange    TiledRange for resulting Cholesky factor. If left
+ * empty, will default to array.trange()
  *
  *  @returns The lower triangular Cholesky factor L in TA format
  */
 template <typename Array>
-auto cholesky( const Array& A, size_t NB = 128, TiledRange l_trange = TiledRange() ) {
-
+auto cholesky(const Array& A, size_t NB = 128,
+              TiledRange l_trange = TiledRange()) {
   using value_type = typename Array::element_type;
 
   auto& world = A.world();
   auto world_comm = world.mpi.comm().Get_mpi_comm();
   blacspp::Grid grid = blacspp::Grid::square_grid(world_comm);
 
-  world.gop.fence(); // stage ScaLAPACK execution
-  auto matrix = array_to_block_cyclic( A, grid, NB, NB );
-  world.gop.fence(); // stage ScaLAPACK execution
+  world.gop.fence();  // stage ScaLAPACK execution
+  auto matrix = array_to_block_cyclic(A, grid, NB, NB);
+  world.gop.fence();  // stage ScaLAPACK execution
 
   auto [M, N] = matrix.dims();
-  if( M != N )
-    throw std::runtime_error("Matrix must be square for Cholesky");
+  if (M != N) throw std::runtime_error("Matrix must be square for Cholesky");
 
   auto [Mloc, Nloc] = matrix.dist().get_local_dims(N, N);
   auto desc = matrix.dist().descinit_noerror(N, N, Mloc);
 
-  auto info = scalapackpp::ppotrf( blacspp::Triangle::Lower, N,
-    matrix.local_mat().data(), 1, 1, desc );
+  auto info = scalapackpp::ppotrf(blacspp::Triangle::Lower, N,
+                                  matrix.local_mat().data(), 1, 1, desc);
   if (info) throw std::runtime_error("Cholesky Failed");
 
   // Zero out the upper triangle
-  detail::scalapack_zero_triangle( blacspp::Triangle::Upper, matrix );
+  detail::scalapack_zero_triangle(blacspp::Triangle::Upper, matrix);
 
-  if( l_trange.rank() == 0 ) l_trange = A.trange();
+  if (l_trange.rank() == 0) l_trange = A.trange();
 
   world.gop.fence();
-  auto L = block_cyclic_to_array<Array>( matrix, l_trange );
+  auto L = block_cyclic_to_array<Array>(matrix, l_trange);
   world.gop.fence();
-
 
   return L;
-
 }
-
-
-
-
-
-
 
 /**
  *  @brief Compute the inverse of the Cholesky factor of an HPD rank-2 tensor.
@@ -116,191 +107,199 @@ auto cholesky( const Array& A, size_t NB = 128, TiledRange l_trange = TiledRange
  *
  *  @param[in] A           Input array to be diagonalized. Must be rank-2
  *  @param[in] NB          ScaLAPACK blocking factor. Defaults to 128
- *  @param[in] l_trange    TiledRange for resulting inverse Cholesky factor. 
+ *  @param[in] l_trange    TiledRange for resulting inverse Cholesky factor.
  *                         If left empty, will default to array.trange()
  *
  *  @returns The inverse lower triangular Cholesky factor in TA format
  */
 template <typename Array, bool RetL = false>
-auto cholesky_linv( const Array& A, size_t NB = 128, TiledRange l_trange = TiledRange() ) {
-
+auto cholesky_linv(const Array& A, size_t NB = 128,
+                   TiledRange l_trange = TiledRange()) {
   using value_type = typename Array::element_type;
 
   auto& world = A.world();
   auto world_comm = world.mpi.comm().Get_mpi_comm();
   blacspp::Grid grid = blacspp::Grid::square_grid(world_comm);
 
-  world.gop.fence(); // stage ScaLAPACK execution
-  auto matrix = array_to_block_cyclic( A, grid, NB, NB );
-  world.gop.fence(); // stage ScaLAPACK execution
+  world.gop.fence();  // stage ScaLAPACK execution
+  auto matrix = array_to_block_cyclic(A, grid, NB, NB);
+  world.gop.fence();  // stage ScaLAPACK execution
 
   auto [M, N] = matrix.dims();
-  if( M != N )
-    throw std::runtime_error("Matrix must be square for Cholesky");
+  if (M != N) throw std::runtime_error("Matrix must be square for Cholesky");
 
   auto [Mloc, Nloc] = matrix.dist().get_local_dims(N, N);
   auto desc = matrix.dist().descinit_noerror(N, N, Mloc);
 
-  auto info = scalapackpp::ppotrf( blacspp::Triangle::Lower, N,
-    matrix.local_mat().data(), 1, 1, desc );
+  auto info = scalapackpp::ppotrf(blacspp::Triangle::Lower, N,
+                                  matrix.local_mat().data(), 1, 1, desc);
   if (info) throw std::runtime_error("Cholesky Failed");
 
   // Zero out the upper triangle
-  detail::scalapack_zero_triangle( blacspp::Triangle::Upper, matrix );
+  detail::scalapack_zero_triangle(blacspp::Triangle::Upper, matrix);
 
   // Copy L if needed
   std::shared_ptr<BlockCyclicMatrix<value_type>> L_sca = nullptr;
   if constexpr (RetL) {
-    L_sca = std::make_shared<BlockCyclicMatrix<value_type>>(
-      world, grid, N, N, NB, NB
-    );
+    L_sca = std::make_shared<BlockCyclicMatrix<value_type>>(world, grid, N, N,
+                                                            NB, NB);
     L_sca->local_mat() = matrix.local_mat();
   }
 
   // Compute inverse
-  info = scalapackpp::ptrtri( blacspp::Triangle::Lower, 
-    blacspp::Diagonal::NonUnit, N, matrix.local_mat().data(), 1, 1, desc );
+  info =
+      scalapackpp::ptrtri(blacspp::Triangle::Lower, blacspp::Diagonal::NonUnit,
+                          N, matrix.local_mat().data(), 1, 1, desc);
   if (info) throw std::runtime_error("TRTRI Failed");
 
-
-  if( l_trange.rank() == 0 ) l_trange = A.trange();
+  if (l_trange.rank() == 0) l_trange = A.trange();
 
   world.gop.fence();
-  auto Linv = block_cyclic_to_array<Array>( matrix, l_trange );
+  auto Linv = block_cyclic_to_array<Array>(matrix, l_trange);
   world.gop.fence();
-
 
   if constexpr (RetL) {
-    auto L = block_cyclic_to_array<Array>( *L_sca, l_trange);
+    auto L = block_cyclic_to_array<Array>(*L_sca, l_trange);
     world.gop.fence();
-    return std::tuple( L, Linv );
+    return std::tuple(L, Linv);
   } else {
     return Linv;
   }
-
 }
 
-
 template <typename Array>
-auto cholesky_solve( const Array& A, const Array& B, size_t NB = 128, 
-  TiledRange x_trange = TiledRange() ) {
-
+auto cholesky_solve(const Array& A, const Array& B, size_t NB = 128,
+                    TiledRange x_trange = TiledRange()) {
   auto& world = A.world();
   /*
   if( world != B.world() ) {
-    throw std::runtime_error("A and B must be distributed on same MADWorld context");
+    throw std::runtime_error("A and B must be distributed on same MADWorld
+  context");
   }
   */
   auto world_comm = world.mpi.comm().Get_mpi_comm();
   blacspp::Grid grid = blacspp::Grid::square_grid(world_comm);
 
-  world.gop.fence(); // stage ScaLAPACK execution
-  auto A_sca = array_to_block_cyclic( A, grid, NB, NB );
-  auto B_sca = array_to_block_cyclic( B, grid, NB, NB );
-  world.gop.fence(); // stage ScaLAPACK execution
+  world.gop.fence();  // stage ScaLAPACK execution
+  auto A_sca = array_to_block_cyclic(A, grid, NB, NB);
+  auto B_sca = array_to_block_cyclic(B, grid, NB, NB);
+  world.gop.fence();  // stage ScaLAPACK execution
 
   auto [M, N] = A_sca.dims();
-  if( M != N )
-    throw std::runtime_error("A must be square for Cholesky Solve");
+  if (M != N) throw std::runtime_error("A must be square for Cholesky Solve");
 
   auto [B_N, NRHS] = B_sca.dims();
-  if( B_N != N )
-    throw std::runtime_error("A and B dims must agree");
-
+  if (B_N != N) throw std::runtime_error("A and B dims must agree");
 
   scalapackpp::scalapack_desc desc_a, desc_b;
   {
-  auto [Mloc, Nloc] = A_sca.dist().get_local_dims(N, N);
-  desc_a = A_sca.dist().descinit_noerror(N, N, Mloc);
+    auto [Mloc, Nloc] = A_sca.dist().get_local_dims(N, N);
+    desc_a = A_sca.dist().descinit_noerror(N, N, Mloc);
   }
 
   {
-  auto [Mloc, Nloc] = B_sca.dist().get_local_dims(N, NRHS);
-  desc_b = B_sca.dist().descinit_noerror(N, NRHS, Mloc);
+    auto [Mloc, Nloc] = B_sca.dist().get_local_dims(N, NRHS);
+    desc_b = B_sca.dist().descinit_noerror(N, NRHS, Mloc);
   }
 
-  auto info = scalapackpp::pposv( blacspp::Triangle::Lower, N, NRHS,
-    A_sca.local_mat().data(), 1, 1, desc_a, B_sca.local_mat().data(),
-    1, 1, desc_b );
+  auto info = scalapackpp::pposv(blacspp::Triangle::Lower, N, NRHS,
+                                 A_sca.local_mat().data(), 1, 1, desc_a,
+                                 B_sca.local_mat().data(), 1, 1, desc_b);
   if (info) throw std::runtime_error("Cholesky Solve Failed");
 
-  if( x_trange.rank() == 0 ) x_trange = B.trange();
+  if (x_trange.rank() == 0) x_trange = B.trange();
 
   world.gop.fence();
-  auto X = block_cyclic_to_array<Array>( B_sca, x_trange );
+  auto X = block_cyclic_to_array<Array>(B_sca, x_trange);
   world.gop.fence();
 
   return X;
 }
 
-
-
-
 template <typename Array>
-auto cholesky_lsolve( scalapackpp::TransposeFlag trans, 
-  const Array& A, const Array& B, size_t NB = 128, 
-  TiledRange l_trange = TiledRange(),
-  TiledRange x_trange = TiledRange() ) {
-
+auto cholesky_lsolve(scalapackpp::TransposeFlag trans, const Array& A,
+                     const Array& B, size_t NB = 128,
+                     TiledRange l_trange = TiledRange(),
+                     TiledRange x_trange = TiledRange()) {
   auto& world = A.world();
   /*
   if( world != B.world() ) {
-    throw std::runtime_error("A and B must be distributed on same MADWorld context");
+    throw std::runtime_error("A and B must be distributed on same MADWorld
+  context");
   }
   */
   auto world_comm = world.mpi.comm().Get_mpi_comm();
   blacspp::Grid grid = blacspp::Grid::square_grid(world_comm);
 
-  world.gop.fence(); // stage ScaLAPACK execution
-  auto A_sca = array_to_block_cyclic( A, grid, NB, NB );
-  auto B_sca = array_to_block_cyclic( B, grid, NB, NB );
-  world.gop.fence(); // stage ScaLAPACK execution
+  world.gop.fence();  // stage ScaLAPACK execution
+  auto A_sca = array_to_block_cyclic(A, grid, NB, NB);
+  auto B_sca = array_to_block_cyclic(B, grid, NB, NB);
+  world.gop.fence();  // stage ScaLAPACK execution
 
   auto [M, N] = A_sca.dims();
-  if( M != N )
-    throw std::runtime_error("A must be square for Cholesky Solve");
+  if (M != N) throw std::runtime_error("A must be square for Cholesky Solve");
 
   auto [B_N, NRHS] = B_sca.dims();
-  if( B_N != N )
-    throw std::runtime_error("A and B dims must agree");
-
+  if (B_N != N) throw std::runtime_error("A and B dims must agree");
 
   scalapackpp::scalapack_desc desc_a, desc_b;
   {
-  auto [Mloc, Nloc] = A_sca.dist().get_local_dims(N, N);
-  desc_a = A_sca.dist().descinit_noerror(N, N, Mloc);
+    auto [Mloc, Nloc] = A_sca.dist().get_local_dims(N, N);
+    desc_a = A_sca.dist().descinit_noerror(N, N, Mloc);
   }
 
   {
-  auto [Mloc, Nloc] = B_sca.dist().get_local_dims(N, NRHS);
-  desc_b = B_sca.dist().descinit_noerror(N, NRHS, Mloc);
+    auto [Mloc, Nloc] = B_sca.dist().get_local_dims(N, NRHS);
+    desc_b = B_sca.dist().descinit_noerror(N, NRHS, Mloc);
   }
 
-  auto info = scalapackpp::ppotrf( blacspp::Triangle::Lower, N,
-    A_sca.local_mat().data(), 1, 1, desc_a );
+  auto info = scalapackpp::ppotrf(blacspp::Triangle::Lower, N,
+                                  A_sca.local_mat().data(), 1, 1, desc_a);
   if (info) throw std::runtime_error("Cholesky Failed");
 
-  info = scalapackpp::ptrtrs( blacspp::Triangle::Lower, trans, 
-    blacspp::Diagonal::NonUnit, N, NRHS, A_sca.local_mat().data(), 1, 1, desc_a,
-    B_sca.local_mat().data(), 1, 1, desc_b );
+  info = scalapackpp::ptrtrs(blacspp::Triangle::Lower, trans,
+                             blacspp::Diagonal::NonUnit, N, NRHS,
+                             A_sca.local_mat().data(), 1, 1, desc_a,
+                             B_sca.local_mat().data(), 1, 1, desc_b);
   if (info) throw std::runtime_error("TRTRS Failed");
 
   // Zero out the upper triangle
-  detail::scalapack_zero_triangle( blacspp::Triangle::Upper, A_sca );
+  detail::scalapack_zero_triangle(blacspp::Triangle::Upper, A_sca);
 
-  if( l_trange.rank() == 0 ) l_trange = A.trange();
-  if( x_trange.rank() == 0 ) x_trange = B.trange();
+  if (l_trange.rank() == 0) l_trange = A.trange();
+  if (x_trange.rank() == 0) x_trange = B.trange();
 
   world.gop.fence();
-  auto L = block_cyclic_to_array<Array>( A_sca, l_trange );
-  auto X = block_cyclic_to_array<Array>( B_sca, x_trange );
+  auto L = block_cyclic_to_array<Array>(A_sca, l_trange);
+  auto X = block_cyclic_to_array<Array>(B_sca, x_trange);
   world.gop.fence();
 
   return std::tuple(L, X);
 }
 
-} // namespace TiledArray
+#else  // TILEDARRAY_HAS_SCALAPACK
 
-#endif // TILEDARRAY_HAS_SCALAPACK
-#endif // TILEDARRAY_MATH_SCALAPACK_H__INCLUDED
+namespace TiledArray::scalapack {
 
+template <typename Array>
+Array cholesky(const Array& A, size_t NB = 128,
+              TiledRange l_trange = TiledRange()) {
+  TA_EXCEPTION("TiledArray was built without ScaLAPACK.");
+}
+
+template <typename Array, bool RetL = false>
+Array cholesky_linv(const Array& A, size_t NB = 128,
+                   TiledRange l_trange = TiledRange()) {
+  TA_EXCEPTION("TiledArray was built without ScaLAPACK.");
+}
+
+template <typename Array>
+Array cholesky_solve(const Array& A, const Array& B, size_t NB = 128,
+                    TiledRange x_trange = TiledRange()) {
+  TA_EXCEPTION("TiledArray was built without ScaLAPACK.");
+}
+
+#endif  // TILEDARRAY_HAS_SCALAPACK
+
+}  // namespace TiledArray::scalapack
+#endif  // TILEDARRAY_MATH_SCALAPACK_H__INCLUDED

--- a/src/TiledArray/math/scalapack/heig.h
+++ b/src/TiledArray/math/scalapack/heig.h
@@ -33,8 +33,7 @@
 #include <scalapackpp/eigenvalue_problem/sevp.hpp>
 #include <scalapackpp/eigenvalue_problem/gevp.hpp>
 
-namespace TiledArray {
-
+namespace TiledArray::scalapack {
 /**
  *  @brief Solve the standard eigenvalue problem with ScaLAPACK
  *
@@ -55,50 +54,43 @@ namespace TiledArray {
  *  as std::vector and in TA format, respectively.
  */
 template <typename Array>
-auto heig( const Array& A, size_t NB = 128, TiledRange evec_trange = TiledRange() ) {
-
+auto heig(const Array& A, size_t NB = 128,
+          TiledRange evec_trange = TiledRange()) {
   using value_type = typename Array::element_type;
-  using real_type  = scalapackpp::detail::real_t<value_type>;
+  using real_type = scalapackpp::detail::real_t<value_type>;
 
   auto& world = A.world();
   auto world_comm = world.mpi.comm().Get_mpi_comm();
-  //auto world_comm = MPI_COMM_WORLD;
+  // auto world_comm = MPI_COMM_WORLD;
   blacspp::Grid grid = blacspp::Grid::square_grid(world_comm);
 
-  world.gop.fence(); // stage ScaLAPACK execution
-  auto matrix = array_to_block_cyclic( A, grid, NB, NB );
-  world.gop.fence(); // stage ScaLAPACK execution
+  world.gop.fence();  // stage ScaLAPACK execution
+  auto matrix = array_to_block_cyclic(A, grid, NB, NB);
+  world.gop.fence();  // stage ScaLAPACK execution
 
   auto [M, N] = matrix.dims();
-  if( M != N )
-    throw std::runtime_error("Matrix must be square for EVP");
+  if (M != N) throw std::runtime_error("Matrix must be square for EVP");
 
   auto [Mloc, Nloc] = matrix.dist().get_local_dims(N, N);
   auto desc = matrix.dist().descinit_noerror(N, N, Mloc);
 
-  std::vector<real_type>        evals( N );
-  BlockCyclicMatrix<value_type> evecs( world, grid, N, N, NB, NB );
+  std::vector<real_type> evals(N);
+  BlockCyclicMatrix<value_type> evecs(world, grid, N, N, NB, NB);
 
   auto info = scalapackpp::hereig(
-    scalapackpp::VectorFlag::Vectors, blacspp::Triangle::Lower, N,
-    matrix.local_mat().data(), 1, 1, desc, evals.data(),
-    evecs.local_mat().data(), 1, 1, desc );
+      scalapackpp::VectorFlag::Vectors, blacspp::Triangle::Lower, N,
+      matrix.local_mat().data(), 1, 1, desc, evals.data(),
+      evecs.local_mat().data(), 1, 1, desc);
   if (info) throw std::runtime_error("EVP Failed");
 
-  if( evec_trange.rank() == 0 ) evec_trange = A.trange();
+  if (evec_trange.rank() == 0) evec_trange = A.trange();
 
   world.gop.fence();
-  auto evecs_ta = block_cyclic_to_array<Array>( evecs, evec_trange );
+  auto evecs_ta = block_cyclic_to_array<Array>(evecs, evec_trange);
   world.gop.fence();
 
-
-  return std::tuple( evals, evecs_ta );
-
+  return std::tuple(evals, evecs_ta);
 }
-
-
-
-
 
 /**
  *  @brief Solve the generalized eigenvalue problem with ScaLAPACK
@@ -125,56 +117,70 @@ auto heig( const Array& A, size_t NB = 128, TiledRange evec_trange = TiledRange(
  *  as std::vector and in TA format, respectively.
  */
 template <typename Array>
-auto heig( const Array& A, const Array& B, 
-  size_t NB = 128, TiledRange evec_trange = TiledRange() ) {
-
+auto heig(const Array& A, const Array& B, size_t NB = 128,
+          TiledRange evec_trange = TiledRange()) {
   using value_type = typename Array::element_type;
-  using real_type  = scalapackpp::detail::real_t<value_type>;
+  using real_type = scalapackpp::detail::real_t<value_type>;
 
   auto& world = A.world();
   auto world_comm = world.mpi.comm().Get_mpi_comm();
-  //auto world_comm = MPI_COMM_WORLD;
+  // auto world_comm = MPI_COMM_WORLD;
   blacspp::Grid grid = blacspp::Grid::square_grid(world_comm);
 
-  world.gop.fence(); // stage ScaLAPACK execution
-  auto A_sca = array_to_block_cyclic( A, grid, NB, NB );
-  auto B_sca = array_to_block_cyclic( B, grid, NB, NB );
-  world.gop.fence(); // stage ScaLAPACK execution
+  world.gop.fence();  // stage ScaLAPACK execution
+  auto A_sca = array_to_block_cyclic(A, grid, NB, NB);
+  auto B_sca = array_to_block_cyclic(B, grid, NB, NB);
+  world.gop.fence();  // stage ScaLAPACK execution
 
   auto [M, N] = A_sca.dims();
-  if( M != N )
-    throw std::runtime_error("Matrix must be square for EVP");
+  if (M != N) throw std::runtime_error("Matrix must be square for EVP");
 
   auto [B_M, B_N] = B_sca.dims();
-  if( B_M != M or B_N != N )
+  if (B_M != M or B_N != N)
     throw std::runtime_error("A and B must have the same dimensions");
 
   auto [Mloc, Nloc] = A_sca.dist().get_local_dims(N, N);
   auto desc = A_sca.dist().descinit_noerror(N, N, Mloc);
 
-  std::vector<real_type>        evals( N );
-  BlockCyclicMatrix<value_type> evecs( world, grid, N, N, NB, NB );
+  std::vector<real_type> evals(N);
+  BlockCyclicMatrix<value_type> evecs(world, grid, N, N, NB, NB);
 
   auto info = scalapackpp::hereig_gen(
-    scalapackpp::VectorFlag::Vectors, blacspp::Triangle::Lower, N,
-    A_sca.local_mat().data(), 1, 1, desc, 
-    B_sca.local_mat().data(), 1, 1, desc, 
-    evals.data(),
-    evecs.local_mat().data(), 1, 1, desc );
+      scalapackpp::VectorFlag::Vectors, blacspp::Triangle::Lower, N,
+      A_sca.local_mat().data(), 1, 1, desc, B_sca.local_mat().data(), 1, 1,
+      desc, evals.data(), evecs.local_mat().data(), 1, 1, desc);
   if (info) throw std::runtime_error("EVP Failed");
 
-  if( evec_trange.rank() == 0 ) evec_trange = A.trange();
+  if (evec_trange.rank() == 0) evec_trange = A.trange();
 
   world.gop.fence();
-  auto evecs_ta = block_cyclic_to_array<Array>( evecs, evec_trange );
+  auto evecs_ta = block_cyclic_to_array<Array>(evecs, evec_trange);
   world.gop.fence();
 
-
-  return std::tuple( evals, evecs_ta );
-
+  return std::tuple(evals, evecs_ta);
 }
 
-} // namespace TiledArray
+} // namespace TiledArray::scalapack
+
+#else // TILEDARRAY_HAS_SCALAPACK
+
+namespace TiledArray::scalapack {
+
+template <typename Array>
+std::tuple<std::vector<typename Array::numeric_type>, Array>
+heig(const Array& A, size_t NB = 128,
+          TiledRange evec_trange = TiledRange()) {
+  TA_EXCEPTION("TiledArray was built without ScaLAPACK.");
+}
+
+template <typename Array>
+std::tuple<std::vector<typename Array::numeric_type>, Array>
+heig(const Array& A, const Array& B, size_t NB = 128,
+          TiledRange evec_trange = TiledRange()) {
+  TA_EXCEPTION("TiledArray was built without ScaLAPACK.");
+}
+
+} // namespace TiledArray::scalapack
 
 #endif // TILEDARRAY_HAS_SCALAPACK
 #endif // TILEDARRAY_MATH_SCALAPACK_H__INCLUDED

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -110,6 +110,7 @@ set(ta_test_src_files  ta_test.cpp
     t_tot_tot_contract_.cpp
     tot_tot_tot_contract_.cpp
     einsum.cpp
+    lapack.cpp
 )
 
 if(CUDA_FOUND)

--- a/tests/lapack.cpp
+++ b/tests/lapack.cpp
@@ -1,0 +1,71 @@
+#include "tiledarray.h"
+#include "TiledArray/math/lapack/chol.h"
+#include "TiledArray/math/lapack/heig.h"
+#include "unit_test_config.h"
+
+using namespace TiledArray;
+
+BOOST_AUTO_TEST_SUITE(heig_orthogonal)
+
+BOOST_AUTO_TEST_CASE(two_by_two) {
+  auto& world = get_default_world();
+  TiledRange trange{{0, 1, 2}, {0, 1, 2}};
+  TSpArrayD a(world, trange, {{1.23, 4.56}, {4.56, 7.89}});
+  auto [eval, evecs] = lapack::heig(a);
+
+  TSpArrayD eval_corr(world, TiledRange{{0, 1, 2}}, {-1.08645907, 10.20645907});
+  TSpArrayD evec_corr(world, trange, {{-0.89155766,  0.4529072},
+                                      {0.4529072 ,  0.89155766}});
+
+  std::cout << eval << std::endl;
+  std::cout << evecs << std::endl;
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE(heig_general)
+
+BOOST_AUTO_TEST_CASE(two_by_two) {
+  auto& world = get_default_world();
+  TiledRange trange{{0, 1, 2}, {0, 1, 2}};
+  TSpArrayD a(world, trange, {{1.23, 4.56}, {4.56, 7.89}});
+  TSpArrayD b(world, trange, {{1.00, 0.50}, {0.50, 1.00}});
+  auto [eval, evecs] = lapack::heig(a, b);
+
+  TSpArrayD eval_corr(world, TiledRange{{0, 1, 2}}, {-1.86171399,  7.94171399});
+  TSpArrayD evec_corr(world, trange, {{-1.15165094, 0.0838657},
+                                      {0.6484553, 0.95542611}});
+  std::cout << eval << std::endl;
+  std::cout << evecs << std::endl;
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+
+BOOST_AUTO_TEST_SUITE(chol)
+
+BOOST_AUTO_TEST_CASE(two_by_two) {
+  auto& world = get_default_world();
+  TiledRange trange{{0, 1, 2}, {0, 1, 2}};
+  TSpArrayD a(world, trange, {{1.00, 1.00}, {1.00, 2.00}});
+  auto L = lapack::cholesky(a);
+  std::cout << L << std::endl;
+
+  TSpArrayD L_corr(world, trange, {{1.0, 0.0}, {1.0, 1.0}});
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE(chol_inv)
+
+BOOST_AUTO_TEST_CASE(two_by_two) {
+  auto& world = get_default_world();
+  TiledRange trange{{0, 1, 2}, {0, 1, 2}};
+  TSpArrayD a(world, trange, {{1.00, 1.00}, {1.00, 2.00}});
+  auto linv = lapack::cholesky_linv(a);
+  std::cout << linv << std::endl;
+
+  TSpArrayD ainv_corr(world, trange, {{1.0, 0.0}, {-1.0, 1.0}});
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This just adds an `else if` to use the existing kernels to support calling `einsum` on three non-ToT tensors. Would allow the the `einsum` functionality in LibChemist to be replaced with this function.

TODO? Only the `tot_tot_tot` case is tested through calls to `einsum` in `einsum.cpp`. The kernels for the other possible combinations are tested, but not the paths through the `else if`s in `einsum`.