### PR TITLE
add t_t_t kernel option to einsum

### DIFF
--- a/src/TiledArray/expressions/contraction_helpers.h
+++ b/src/TiledArray/expressions/contraction_helpers.h
@@ -594,6 +594,11 @@ void einsum(TsrExpr<ResultType, true> out,
             tile = kernels::tot_t_tot_contract_(ovars, lvars, rvars, ltile, rtile);
           else
             tile += kernels::tot_t_tot_contract_(ovars, lvars, rvars, ltile, rtile);
+        } else if constexpr(!out_is_tot && !lhs_is_tot && !rhs_is_tot){
+          if(tile.empty())
+            tile = kernels::t_t_t_contract_(ovars, lvars, rvars, ltile, rtile);
+          else
+            tile += kernels::t_t_t_contract_(ovars, lvars, rvars, ltile, rtile);
         } else {
           TA_ASSERT(false);  // Your kernel isn't supported
         }


### PR DESCRIPTION
This just adds an else if to use the existing kernels to support calling einsum on three non-ToT tensors. Would allow the the einsum functionality in LibChemist to be replaced with this function.

TODO? Only the tot_tot_tot case is tested through calls to einsum in einsum.cpp. The kernels for the other possible combinations are tested, but not the paths through the else ifs in einsum.